### PR TITLE
Synchronization with MARTE/DAM and DTSM::Core and DTSM::Storm

### DIFF
--- a/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
+++ b/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
   <notation:Diagram xmi:id="_MQbYoOePEeWj7ZPL8JeBTQ" type="PapyrusUMLProfileDiagram" name="DPIM" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_DcWj0OejEeWj7ZPL8JeBTQ" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_DcWj0uejEeWj7ZPL8JeBTQ" type="1034"/>
@@ -373,7 +373,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4I1-ipnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_lG6AcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4IO4SpnEeaibdPncpUwfA" x="142" y="268"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4IO4SpnEeaibdPncpUwfA" x="30" y="217"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4JdACpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4JdAipnEeaibdPncpUwfA" type="1034"/>
@@ -390,7 +390,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdDCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_r1_uoCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdASpnEeaibdPncpUwfA" x="342" y="481"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdASpnEeaibdPncpUwfA" x="291" y="217"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4KEECpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4KEEipnEeaibdPncpUwfA" type="1034"/>
@@ -419,7 +419,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEHCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_slNlECluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEESpnEeaibdPncpUwfA" x="314" y="659"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEESpnEeaibdPncpUwfA" x="300" y="424"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4KrICpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4KrIipnEeaibdPncpUwfA" type="1034"/>
@@ -431,10 +431,6 @@
         <children xmi:type="notation:Shape" xmi:id="_vcpSECpnEeaibdPncpUwfA" type="3002">
           <element xmi:type="uml:Property" href="DICE.profile.uml#_jOHA4ClwEeaibdPncpUwfA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_vcpSESpnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_PfFeYCppEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_PewuQCppEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_PfFeYSppEeaibdPncpUwfA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_l4KrJCpnEeaibdPncpUwfA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_l4KrJSpnEeaibdPncpUwfA"/>
@@ -448,65 +444,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrLCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_uKIUcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrISpnEeaibdPncpUwfA" x="727" y="72"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4KrLSpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4KrLypnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4KrMCpnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_24bHIipnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_bqdMwClxEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_24bHIypnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_24buMCpnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_gbONEClxEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_24buMSpnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_24buMipnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_9PHncCo7EeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_24buMypnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_24buNCpnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_fu_qQCpjEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_24buNSpnEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4KrMSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4KrMipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4KrMypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrNCpnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4KrNSpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4KrNipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4KrNypnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4KrOCpnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrOSpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_v0dIQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrLipnEeaibdPncpUwfA" x="1677" y="60"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4LSMCpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4LSMipnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4LSMypnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_0pRvACpnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_4GkoEClxEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0pRvASpnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0pRvAipnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_6qMbYClxEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0pRvAypnEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4LSNCpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4LSNSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4LSNipnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4LSNypnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4LSOCpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4LSOSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4LSOipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4LSOypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4LSPCpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_xby5gCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4LSMSpnEeaibdPncpUwfA" x="1684" y="266"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrISpnEeaibdPncpUwfA" x="459" y="16"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4L5SypnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4L5TSpnEeaibdPncpUwfA" type="1034"/>
@@ -527,57 +465,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5VypnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_2HB5kCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5TCpnEeaibdPncpUwfA" x="997" y="291"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4MgUCpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4MgUipnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4MgUypnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_OTVAcCpqEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_OTCFgCpqEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_OTVAcSpqEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4MgVCpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4MgVSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4MgVipnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4MgVypnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4MgWCpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4MgWSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4MgWipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4MgWypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4MgXCpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_4a1vQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4MgUSpnEeaibdPncpUwfA" x="1152" y="510"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4MgXSpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4MgXypnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4NHYCpnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_6jj0wCpqEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_6jBpQCpqEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_6jj0wSpqEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_YP_BYCprEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_YPsGcCprEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_YP_BYSprEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_1ZVWICprEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_1Y3cECprEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_1ZVWISprEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4NHYSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4NHYipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4NHYypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHZCpnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4NHZSpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4NHZipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4NHZypnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4NHaCpnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHaSpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_6kF6wCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4MgXipnEeaibdPncpUwfA" x="487" y="265"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5TCpnEeaibdPncpUwfA" x="699" y="217"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4NHaipnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4NHbCpnEeaibdPncpUwfA" type="1034"/>
@@ -606,7 +494,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHdipnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_8x7EQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHaypnEeaibdPncpUwfA" x="1335" y="275"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHaypnEeaibdPncpUwfA" x="451" y="217"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4NucCpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4NucipnEeaibdPncpUwfA" type="1034"/>
@@ -627,86 +515,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NufCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_9mn3oCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NucSpnEeaibdPncpUwfA" x="1358" y="646"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4NufSpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4NufypnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4OVgCpnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_EeTG8CpoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_1jo3kCo9EeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EeTG8SpoEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_7uTUICprEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_7t_yICprEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_7uTUISprEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4OVgSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4OVgipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4OVgypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4OVhCpnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4OVhSpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4OVhipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4OVhypnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4OViCpnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4OViSpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_CM--wClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NufipnEeaibdPncpUwfA" x="614" y="523"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4OViipnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4OVjCpnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4OVjSpnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_EeR40CpoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_zWylgCo9EeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EeR40SpoEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_ACGroCpsEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_ABzJoCpsEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ACGroSpsEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4O8kCpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4O8kSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4O8kipnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4O8kypnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4O8lCpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4O8lSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4O8lipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4O8lypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4O8mCpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Cna4AClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4OViypnEeaibdPncpUwfA" x="773" y="284"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4PjoCpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4PjoipnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4PjoypnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_EeU8ICpoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_Ev-_oClyEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EeU8ISpoEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_EeU8IipoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_KoWhMClyEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EeU8IypoEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_EeU8JCpoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_CjJfMClzEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_EeU8JSpoEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4PjpCpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4PjpSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4PjpipnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4PjpypnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4PjqCpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4PjqSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4PjqipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4PjqypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4PjrCpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Fc0-4ClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4PjoSpnEeaibdPncpUwfA" x="1671" y="456"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NucSpnEeaibdPncpUwfA" x="491" y="424"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4QKsCpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4QKsipnEeaibdPncpUwfA" type="1034"/>
@@ -735,7 +544,20 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKvCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_KUZx0ClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKsSpnEeaibdPncpUwfA" x="838" y="505"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKsSpnEeaibdPncpUwfA" x="973" y="217"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x_sCAC5WEeaF_sH3mLTVKg" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_x_sCAi5WEeaF_sH3mLTVKg" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_sCAS5WEeaF_sH3mLTVKg" x="706" y="36"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_x_yvsC5WEeaF_sH3mLTVKg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_x_yvsS5WEeaF_sH3mLTVKg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_yvsy5WEeaF_sH3mLTVKg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_yvsi5WEeaF_sH3mLTVKg" x="200"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_fqSMkSpnEeaibdPncpUwfA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_fqSMkipnEeaibdPncpUwfA"/>
@@ -744,35 +566,31 @@
     </styles>
     <styles xmi:type="notation:CanonicalStyle" xmi:id="_l35lYCpnEeaibdPncpUwfA"/>
     <element xmi:type="uml:Package" href="DICE.profile.uml#_Q9bJsCluEeaibdPncpUwfA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_TUb0wCpoEeaibdPncpUwfA" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_TUb0wypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_TUb0xCpoEeaibdPncpUwfA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_TUb0wSpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_D-3yQCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TUb0wipoEeaibdPncpUwfA" points="[194, 0, 703, 68]$[194, -36, 703, 32]$[-509, -36, 0, 32]$[-509, -68, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiRCpoEeaibdPncpUwfA" id="(0.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiRSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_UdiK0CpoEeaibdPncpUwfA" type="4002" source="_l4IO4CpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buvP0C5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buv24C5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_UdiK0ypoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Udix4CpoEeaibdPncpUwfA" x="74" y="-26"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_UdiK0SpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Usr0QClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UdiK0ipoEeaibdPncpUwfA" points="[-132, 0, -586, 61]$[-132, -29, -586, 32]$[454, -29, 0, 32]$[454, -61, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVCpoEeaibdPncpUwfA" id="(1.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UdiK0ipoEeaibdPncpUwfA" points="[0, -55, -228, 178]$[0, -113, -228, 120]$[297, -113, 69, 120]$[297, -145, 69, 88]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVCpoEeaibdPncpUwfA" id="(1.0,0.34591194968553457)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVSpoEeaibdPncpUwfA" id="(0.0,0.2072072072072072)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VQfRwCpoEeaibdPncpUwfA" type="4002" source="_l4JdACpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buf_QC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buf_QS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_VQf40SpoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VQf40ipoEeaibdPncpUwfA" x="-14" y="-26"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VQfRwSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Vhf8YClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQf40CpoEeaibdPncpUwfA" points="[0, 0, -409, 274]$[0, -242, -409, 32]$[409, -242, 0, 32]$[409, -274, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsipoEeaibdPncpUwfA" id="(0.75,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUK4wCpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQf40CpoEeaibdPncpUwfA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsipoEeaibdPncpUwfA" id="(0.87,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUK4wCpoEeaibdPncpUwfA" id="(0.0,0.6576576576576577)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VwfngCpoEeaibdPncpUwfA" type="4002" source="_l4KEECpnEeaibdPncpUwfA" target="_l4JdACpnEeaibdPncpUwfA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_VwfngypoEeaibdPncpUwfA" visible="false" type="6007">
@@ -780,49 +598,22 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VwfngSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_V7slEClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VwfngipoEeaibdPncpUwfA" points="[0, 0, 23, 78]$[0, -78, 23, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsCpoEeaibdPncpUwfA" id="(0.5306122448979592,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VwfngipoEeaibdPncpUwfA" points="[0, 0, 0, -60]$[0, 60, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsCpoEeaibdPncpUwfA" id="(0.3969465648854962,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsSpoEeaibdPncpUwfA" id="(0.61,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YwvFYCpoEeaibdPncpUwfA" type="4002" source="_l4L5SypnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buoiIC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buoiIS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_YwvscCpoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_YwvscSpoEeaibdPncpUwfA" y="60"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_YwvFYSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_AFtIUCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YwvFYipoEeaibdPncpUwfA" points="[0, 0, 288, 84]$[0, -52, 288, 32]$[-288, -52, 0, 32]$[-288, -84, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQipoEeaibdPncpUwfA" id="(0.46987951807228917,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQypoEeaibdPncpUwfA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ZruuACpoEeaibdPncpUwfA" type="4002" source="_l4MgUCpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_ZruuAypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZruuBCpoEeaibdPncpUwfA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_ZruuASpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#__hxU0CpiEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZruuAipoEeaibdPncpUwfA" points="[63, 0, 447, 303]$[63, -271, 447, 32]$[-384, -271, 0, 32]$[-384, -303, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJUipoEeaibdPncpUwfA" id="(0.21641791044776118,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJUypoEeaibdPncpUwfA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_ag9F0CpoEeaibdPncpUwfA" type="4002" source="_l4MgXSpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_ag9F0ypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ag9F1CpoEeaibdPncpUwfA" x="7" y="-19"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_ag9F0SpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_G0GS8CpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ag9F0ipoEeaibdPncpUwfA" points="[0, 0, -208, 58]$[0, -26, -208, 32]$[208, -26, 0, 32]$[208, -58, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiSCpoEeaibdPncpUwfA" id="(0.808641975308642,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiSSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_bDFigCpoEeaibdPncpUwfA" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_bDGJkCpoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_bDGJkSpoEeaibdPncpUwfA" x="26" y="54"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_bDFigSpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_D-3yQCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bDFigipoEeaibdPncpUwfA" points="[106, 0, 615, 68]$[106, -36, 615, 32]$[-509, -36, 0, 32]$[-509, -68, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUY7MCpoEeaibdPncpUwfA" id="(0.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUY7MSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YwvFYipoEeaibdPncpUwfA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQipoEeaibdPncpUwfA" id="(0.102803738317757,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQypoEeaibdPncpUwfA" id="(1.0,0.4864864864864865)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_buPYUCpoEeaibdPncpUwfA" type="4002" source="_l4NucCpnEeaibdPncpUwfA" target="_l4NHaipnEeaibdPncpUwfA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_buPYUypoEeaibdPncpUwfA" visible="false" type="6007">
@@ -830,39 +621,52 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_buPYUSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_CjRW8CpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_buPYUipoEeaibdPncpUwfA" points="[0, 0, 10, 258]$[0, -258, 10, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoCpoEeaibdPncpUwfA" id="(0.4627659574468085,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoSpoEeaibdPncpUwfA" id="(0.497737556561086,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cVuPECpoEeaibdPncpUwfA" type="4002" source="_l4NufSpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_cVuPEypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_cVuPFCpoEeaibdPncpUwfA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_cVuPESpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_ICAQgCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cVuPEipoEeaibdPncpUwfA" points="[-33, 0, -123, 316]$[-33, -284, -123, 32]$[90, -284, 0, 32]$[90, -316, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUY7MipoEeaibdPncpUwfA" id="(0.7625,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUY7MypoEeaibdPncpUwfA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_c6UJ4CpoEeaibdPncpUwfA" type="4002" source="_l4OViipnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_c6UJ4ypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_c6UJ5CpoEeaibdPncpUwfA" x="-19" y="33"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_c6UJ4SpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_JV3sICpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c6UJ4ipoEeaibdPncpUwfA" points="[0, 0, 77, 77]$[0, -45, 77, 32]$[-77, -45, 0, 32]$[-77, -77, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiRipoEeaibdPncpUwfA" id="(0.8125,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiRypoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_buPYUipoEeaibdPncpUwfA" points="[0, 0, 0, -87]$[0, 87, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoCpoEeaibdPncpUwfA" id="(0.4329268292682927,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoSpoEeaibdPncpUwfA" id="(0.5904255319148937,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_d0ZMgCpoEeaibdPncpUwfA" type="4002" source="_l4QKsCpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buszkC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buszkS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_d0ZMgypoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_d0ZMhCpoEeaibdPncpUwfA" x="6" y="50"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_d0ZMgSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_VHGfYClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d0ZMgipoEeaibdPncpUwfA" points="[-60, 0, 144, 298]$[-60, -266, 144, 32]$[-204, -266, 0, 32]$[-204, -298, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQCpoEeaibdPncpUwfA" id="(0.7191011235955056,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQSpoEeaibdPncpUwfA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d0ZMgipoEeaibdPncpUwfA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQCpoEeaibdPncpUwfA" id="(0.0,0.41732283464566927)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQSpoEeaibdPncpUwfA" id="(1.0,0.12612612612612611)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Z30KcC5TEeaF_sH3mLTVKg" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bule0C5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bule0S5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Z30Kcy5TEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z30KdC5TEeaF_sH3mLTVKg" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Z30KcS5TEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Z3pLUC5TEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z30Kci5TEeaF_sH3mLTVKg"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z4ECEC5TEeaF_sH3mLTVKg" id="(0.4627659574468085,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z4ECES5TEeaF_sH3mLTVKg" id="(0.5362318840579711,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x_yvtC5WEeaF_sH3mLTVKg" type="StereotypeCommentLink" source="_x_sCAC5WEeaF_sH3mLTVKg" target="_x_yvsC5WEeaF_sH3mLTVKg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_x_yvtS5WEeaF_sH3mLTVKg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_yvuS5WEeaF_sH3mLTVKg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x_yvti5WEeaF_sH3mLTVKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_yvty5WEeaF_sH3mLTVKg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_yvuC5WEeaF_sH3mLTVKg"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_x__kAC5WEeaF_sH3mLTVKg" type="1013" source="_l4KrICpnEeaibdPncpUwfA" target="_x_sCAC5WEeaF_sH3mLTVKg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yAALEC5WEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_uHeZcCpoEeaibdPncpUwfA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yAALES5WEeaF_sH3mLTVKg" points="[-69, -9, 459, 62]$[-528, -71, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybnJAC5WEeaF_sH3mLTVKg" id="(1.0,0.5765765765765766)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybnwEC5WEeaF_sH3mLTVKg" id="(0.0,0.36)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_MFeaECpwEeaibdPncpUwfA" type="PapyrusUMLProfileDiagram" name="DTSM::Storm" measurementUnit="Pixel">
@@ -1185,6 +989,174 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e5U6oipwEeaibdPncpUwfA" points="[0, 0, -52, 123]$[0, -123, -52, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5kyQCpwEeaibdPncpUwfA" id="(0.3853658536585366,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5kyQSpwEeaibdPncpUwfA" id="(0.6396396396396397,1.0)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_Jyg_AC5MEeaF_sH3mLTVKg" type="PapyrusUMLProfileDiagram" name="DTSM::Hadoop" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_inTuUC5MEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_inUVYC5MEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_inUVYS5MEeaF_sH3mLTVKg" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_1G85cC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_OTCFgCpqEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_1G85cS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_inUVYi5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_inUVYy5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_inUVZC5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inUVZS5MEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_inUVZi5MEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_inUVZy5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_inUVaC5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_inUVaS5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inUVai5MEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_4a1vQCluEeaibdPncpUwfA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inTuUS5MEeaF_sH3mLTVKg" x="82" y="460"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_inZ08C5MEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_inZ08i5MEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_inZ08y5MEeaF_sH3mLTVKg" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_2Rv4oC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_6jBpQCpqEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2Rv4oS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2RzjAC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_YPsGcCprEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2RzjAS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2R3NYC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_1Y3cECprEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2R3NYS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_inZ09C5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_inZ09S5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_inZ09i5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ09y5MEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_inZ0-C5MEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_inZ0-S5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_inZ0-i5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_inZ0-y5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ0_C5MEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_6kF6wCluEeaibdPncpUwfA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ08S5MEeaF_sH3mLTVKg" x="374" y="460"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_infUgC5MEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_infUgi5MEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_infUgy5MEeaF_sH3mLTVKg" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_3ecVQC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_1jo3kCo9EeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_3ecVQS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_3egmsC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_7t_yICprEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_3egmsS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_infUhC5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_infUhS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_infUhi5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUhy5MEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_infUiC5MEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_infUiS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_infUii5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_infUiy5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUjC5MEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_CM--wClvEeaibdPncpUwfA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUgS5MEeaF_sH3mLTVKg" x="577" y="460"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ink0EC5MEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ink0Ei5MEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ink0Ey5MEeaF_sH3mLTVKg" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_4SYToC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_zWylgCo9EeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4SYToS5MEeaF_sH3mLTVKg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_4SclEC5MEeaF_sH3mLTVKg" type="3002">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_ABzJoCpsEeaibdPncpUwfA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_4SclES5MEeaF_sH3mLTVKg"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ink0FC5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ink0FS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ink0Fi5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ink0Fy5MEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_inlbIC5MEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_inlbIS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_inlbIi5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_inlbIy5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inlbJC5MEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Cna4AClvEeaibdPncpUwfA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ink0ES5MEeaF_sH3mLTVKg" x="778" y="460"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_xINzAC5MEeaF_sH3mLTVKg" type="1026">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_D5W90C5NEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_D5W90S5NEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_xINzAi5MEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xINzAy5MEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xINzBC5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xINzBS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xINzBi5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzBy5MEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xINzCC5MEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xINzCS5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xINzCi5MEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xINzCy5MEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzDC5MEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_uKIUcCluEeaibdPncpUwfA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzAS5MEeaF_sH3mLTVKg" x="432" y="217"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_Jyg_AS5MEeaF_sH3mLTVKg" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_Jyg_Ai5MEeaF_sH3mLTVKg"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_Jyg_Ay5MEeaF_sH3mLTVKg">
+      <owner xmi:type="uml:Profile" href="DICE.profile.uml#_MPXosOePEeWj7ZPL8JeBTQ"/>
+    </styles>
+    <element xmi:type="uml:Profile" href="DICE.profile.uml#_lhjuYC5LEeaF_sH3mLTVKg"/>
+    <edges xmi:type="notation:Connector" xmi:id="_xIk_YC5MEeaF_sH3mLTVKg" type="4002" source="_inTuUC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xIlmcC5MEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xIlmcS5MEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_xIk_YS5MEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#__hxU0CpiEeaibdPncpUwfA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xIk_Yi5MEeaF_sH3mLTVKg" points="[0, 0, -306, -87]$[306, 87, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHLAC5MEeaF_sH3mLTVKg" id="(0.8922413793103449,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHLAS5MEeaF_sH3mLTVKg" id="(0.0,0.21)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_xtAiIC5MEeaF_sH3mLTVKg" type="4002" source="_inZ08C5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xtAiIy5MEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_xtAiJC5MEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_xtAiIS5MEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_G0GS8CpjEeaibdPncpUwfA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xtAiIi5MEeaF_sH3mLTVKg" points="[0, 0, -79, -60]$[79, 60, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4_aYwC5MEeaF_sH3mLTVKg" id="(0.6083916083916084,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4_aYwS5MEeaF_sH3mLTVKg" id="(0.29,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_yjuuwC5MEeaF_sH3mLTVKg" type="4002" source="_infUgC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yjuuwy5MEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_yjuuxC5MEeaF_sH3mLTVKg" x="-59" y="-29"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_yjuuwS5MEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_ICAQgCpjEeaibdPncpUwfA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yjuuwi5MEeaF_sH3mLTVKg" points="[0, 0, 103, -76]$[-103, 76, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40lBwC5MEeaF_sH3mLTVKg" id="(0.09219858156028368,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40lBwS5MEeaF_sH3mLTVKg" id="(1.0,0.78)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zOpUAC5MEeaF_sH3mLTVKg" type="4002" source="_ink0EC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
+      <children xmi:type="notation:DecorationNode" xmi:id="_zOpUAy5MEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_zOpUBC5MEeaF_sH3mLTVKg" x="-149" y="-46"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_zOpUAS5MEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_JV3sICpjEeaibdPncpUwfA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zOpUAi5MEeaF_sH3mLTVKg" points="[0, 0, 284, -76]$[-284, 76, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4pa6oC5MEeaF_sH3mLTVKg" id="(0.0,0.43243243243243246)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4pa6oS5MEeaF_sH3mLTVKg" id="(1.0,0.17)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
+++ b/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
@@ -247,6 +247,43 @@
       <element xmi:type="uml:Stereotype" href="pathmap://DAM_PROFILES/DAM.profile.uml#_fdgTgOP9EeKmVK0_L5xJcQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ThGSceemEeWj7ZPL8JeBTQ" x="1117" y="93"/>
     </children>
+    <children xmi:type="notation:Shape" xmi:id="_xjozoC5gEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_xjpasC5gEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xjpasS5gEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xjpasi5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xjpasy5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xjpatC5gEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xjpatS5gEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_xjpati5gEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_xjpaty5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_xjpauC5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_xjpauS5gEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xjpaui5gEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_xjoMkC5gEeaF_sH3mLTVKg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xjozoS5gEeaF_sH3mLTVKg" x="-169" y="508"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_63FU8C5gEeaF_sH3mLTVKg" type="1026" fillColor="8047085">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__z8QgC5gEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__z8QgS5gEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_63F8AC5gEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_63F8AS5gEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_63F8Ai5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_63F8Ay5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_63F8BC5gEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_63F8BS5gEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_63F8Bi5gEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_63F8By5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_63F8CC5gEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_63F8CS5gEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_63F8Ci5gEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_63FU8S5gEeaF_sH3mLTVKg" x="-204" y="278"/>
+    </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_MQbYoeePEeWj7ZPL8JeBTQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_MQbYouePEeWj7ZPL8JeBTQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_MQbYo-ePEeWj7ZPL8JeBTQ">
@@ -333,6 +370,16 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xj3kUOemEeWj7ZPL8JeBTQ" id="(0.5365079365079365,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xj3kUeemEeWj7ZPL8JeBTQ" id="(0.5493562231759657,1.0)"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_70IMAC5gEeaF_sH3mLTVKg" type="4002" source="_xjozoC5gEeaF_sH3mLTVKg" target="_63FU8C5gEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_70IMAy5gEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_70IMBC5gEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_70IMAS5gEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_70CFYC5gEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_70IMAi5gEeaF_sH3mLTVKg" points="[5, -14, -43, 109]$[48, -144, 0, -21]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_70Z40C5gEeaF_sH3mLTVKg" id="(0.48,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PViOwC5kEeaF_sH3mLTVKg" id="(0.4689265536723164,1.0)"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_fqSMkCpnEeaibdPncpUwfA" type="PapyrusUMLProfileDiagram" name="DTSM::Core" measurementUnit="Pixel">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_l38BoCpnEeaibdPncpUwfA" source="PapyrusCSSForceValue">
@@ -341,10 +388,6 @@
     <children xmi:type="notation:Shape" xmi:id="_l4IO4CpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4I18CpnEeaibdPncpUwfA" type="1034"/>
       <children xmi:type="notation:BasicCompartment" xmi:id="_l4I18SpnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_GAFp0CpoEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_imBwUCo4EeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_GAFp0SpoEeaibdPncpUwfA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_GAFp0ipoEeaibdPncpUwfA" type="3002">
           <element xmi:type="uml:Property" href="DICE.profile.uml#_oWUlECpmEeaibdPncpUwfA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_GAFp0ypoEeaibdPncpUwfA"/>
@@ -373,7 +416,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4I1-ipnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_lG6AcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4IO4SpnEeaibdPncpUwfA" x="30" y="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4IO4SpnEeaibdPncpUwfA" x="-9" y="415"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4JdACpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4JdAipnEeaibdPncpUwfA" type="1034"/>
@@ -390,7 +433,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdDCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_r1_uoCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdASpnEeaibdPncpUwfA" x="291" y="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4JdASpnEeaibdPncpUwfA" x="252" y="415"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4KEECpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4KEEipnEeaibdPncpUwfA" type="1034"/>
@@ -419,32 +462,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEHCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_slNlECluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEESpnEeaibdPncpUwfA" x="300" y="424"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_l4KrICpnEeaibdPncpUwfA" type="1026">
-      <children xmi:type="notation:DecorationNode" xmi:id="_l4KrIipnEeaibdPncpUwfA" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4KrIypnEeaibdPncpUwfA" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_vcorACpnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_LO7q8ClwEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_vcorASpnEeaibdPncpUwfA"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_vcpSECpnEeaibdPncpUwfA" type="3002">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_jOHA4ClwEeaibdPncpUwfA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_vcpSESpnEeaibdPncpUwfA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4KrJCpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4KrJSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4KrJipnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrJypnEeaibdPncpUwfA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_l4KrKCpnEeaibdPncpUwfA" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_l4KrKSpnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_l4KrKipnEeaibdPncpUwfA"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_l4KrKypnEeaibdPncpUwfA"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrLCpnEeaibdPncpUwfA"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_uKIUcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KrISpnEeaibdPncpUwfA" x="459" y="16"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4KEESpnEeaibdPncpUwfA" x="261" y="622"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4L5SypnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4L5TSpnEeaibdPncpUwfA" type="1034"/>
@@ -465,7 +483,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5VypnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_2HB5kCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5TCpnEeaibdPncpUwfA" x="699" y="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4L5TCpnEeaibdPncpUwfA" x="819" y="484"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4NHaipnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4NHbCpnEeaibdPncpUwfA" type="1034"/>
@@ -494,7 +512,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHdipnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_8x7EQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHaypnEeaibdPncpUwfA" x="451" y="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NHaypnEeaibdPncpUwfA" x="471" y="426"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4NucCpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4NucipnEeaibdPncpUwfA" type="1034"/>
@@ -515,7 +533,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NufCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_9mn3oCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NucSpnEeaibdPncpUwfA" x="491" y="424"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4NucSpnEeaibdPncpUwfA" x="484" y="631"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_l4QKsCpnEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_l4QKsipnEeaibdPncpUwfA" type="1034"/>
@@ -544,20 +562,120 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKvCpnEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_KUZx0ClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKsSpnEeaibdPncpUwfA" x="973" y="217"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l4QKsSpnEeaibdPncpUwfA" x="1089" y="482"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_x_sCAC5WEeaF_sH3mLTVKg" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_x_sCAi5WEeaF_sH3mLTVKg" type="1084"/>
+    <children xmi:type="notation:Shape" xmi:id="_EL_AEC5nEeaF_sH3mLTVKg" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_EL_AEi5nEeaF_sH3mLTVKg" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_sCAS5WEeaF_sH3mLTVKg" x="706" y="36"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EL_AES5nEeaF_sH3mLTVKg" x="1025" y="295"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_x_yvsC5WEeaF_sH3mLTVKg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_x_yvsS5WEeaF_sH3mLTVKg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_yvsy5WEeaF_sH3mLTVKg" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_EMFGsy5nEeaF_sH3mLTVKg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_EMFGtC5nEeaF_sH3mLTVKg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EMFGti5nEeaF_sH3mLTVKg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x_yvsi5WEeaF_sH3mLTVKg" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EMFGtS5nEeaF_sH3mLTVKg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GV9kUC5nEeaF_sH3mLTVKg" type="1026" fillColor="10265827">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SCUdxC5nEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SCUdxS5nEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GV9kUi5nEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_GV9kUy5nEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_GV9kVC5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_GV9kVS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_GV9kVi5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GV9kVy5nEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_GV9kWC5nEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_GV9kWS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_GV9kWi5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_GV9kWy5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GV9kXC5nEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_C9h50OejEeWj7ZPL8JeBTQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GV9kUS5nEeaF_sH3mLTVKg" x="16" y="184"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HOE4EC5nEeaF_sH3mLTVKg" type="1026" fillColor="10265827">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SCUdwi5nEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SCUdwy5nEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HOE4Ei5nEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HOE4Ey5nEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HOE4FC5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HOE4FS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HOE4Fi5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HOE4Fy5nEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HOE4GC5nEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HOE4GS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HOE4Gi5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HOE4Gy5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HOE4HC5nEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_kiO_kOejEeWj7ZPL8JeBTQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HOE4ES5nEeaF_sH3mLTVKg" x="227" y="188"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Ir9LUC5nEeaF_sH3mLTVKg" type="1026" fillColor="10265827">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SCUdwC5nEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SCUdwS5nEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Ir9LUi5nEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Ir9LUy5nEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Ir9LVC5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Ir9LVS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Ir9LVi5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ir9LVy5nEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Ir9LWC5nEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Ir9LWS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Ir9LWi5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Ir9LWy5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ir9LXC5nEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_iCtCEOejEeWj7ZPL8JeBTQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ir9LUS5nEeaF_sH3mLTVKg" x="420" y="186"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_IsQtUC5nEeaF_sH3mLTVKg" type="1026" fillColor="8047085">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S8QWcC5nEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S8QWcS5nEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IsQtUi5nEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_IsQtUy5nEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_IsQtVC5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_IsQtVS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_IsQtVi5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IsQtVy5nEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_IsQtWC5nEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_IsQtWS5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_IsQtWi5nEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_IsQtWy5nEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IsQtXC5nEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_eXMtwBKZEdyGYuetzx6T5A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IsQtUS5nEeaF_sH3mLTVKg" x="600" y="187"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AFe9YC5qEeaF_sH3mLTVKg" type="1026" fillColor="8047085">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CMBzIC5qEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CMBzIS5qEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AFe9Yi5qEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AFe9Yy5qEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AFe9ZC5qEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AFe9ZS5qEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AFe9Zi5qEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AFe9Zy5qEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AFe9aC5qEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AFe9aS5qEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AFe9ai5qEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AFe9ay5qEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AFe9bC5qEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AFe9YS5qEeaF_sH3mLTVKg" x="804" y="187"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_fqSMkSpnEeaibdPncpUwfA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_fqSMkipnEeaibdPncpUwfA"/>
@@ -566,107 +684,105 @@
     </styles>
     <styles xmi:type="notation:CanonicalStyle" xmi:id="_l35lYCpnEeaibdPncpUwfA"/>
     <element xmi:type="uml:Package" href="DICE.profile.uml#_Q9bJsCluEeaibdPncpUwfA"/>
-    <edges xmi:type="notation:Connector" xmi:id="_UdiK0CpoEeaibdPncpUwfA" type="4002" source="_l4IO4CpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buvP0C5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buv24C5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+    <edges xmi:type="notation:Connector" xmi:id="_VwfngCpoEeaibdPncpUwfA" type="4002" source="_l4KEECpnEeaibdPncpUwfA" target="_l4JdACpnEeaibdPncpUwfA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_uo35YC5lEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_uo35YS5lEeaF_sH3mLTVKg" key="routing" value="true"/>
       </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_UdiK0ypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Udix4CpoEeaibdPncpUwfA" x="74" y="-26"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_UdiK0SpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Usr0QClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UdiK0ipoEeaibdPncpUwfA" points="[0, -55, -228, 178]$[0, -113, -228, 120]$[297, -113, 69, 120]$[297, -145, 69, 88]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVCpoEeaibdPncpUwfA" id="(1.0,0.34591194968553457)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUaJVSpoEeaibdPncpUwfA" id="(0.0,0.2072072072072072)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_VQfRwCpoEeaibdPncpUwfA" type="4002" source="_l4JdACpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buf_QC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buf_QS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_VQf40SpoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_VQf40ipoEeaibdPncpUwfA" x="-14" y="-26"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_VQfRwSpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Vhf8YClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQf40CpoEeaibdPncpUwfA"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsipoEeaibdPncpUwfA" id="(0.87,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUK4wCpoEeaibdPncpUwfA" id="(0.0,0.6576576576576577)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_VwfngCpoEeaibdPncpUwfA" type="4002" source="_l4KEECpnEeaibdPncpUwfA" target="_l4JdACpnEeaibdPncpUwfA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_VwfngypoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_VwfnhCpoEeaibdPncpUwfA" y="60"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_VwfngSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_V7slEClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VwfngipoEeaibdPncpUwfA" points="[0, 0, 0, -60]$[0, 60, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VwfngipoEeaibdPncpUwfA"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsCpoEeaibdPncpUwfA" id="(0.3969465648854962,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUKRsSpoEeaibdPncpUwfA" id="(0.61,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_YwvFYCpoEeaibdPncpUwfA" type="4002" source="_l4L5SypnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buoiIC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buoiIS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
+    <edges xmi:type="notation:Connector" xmi:id="_buPYUCpoEeaibdPncpUwfA" type="4002" source="_l4NucCpnEeaibdPncpUwfA" target="_l4NHaipnEeaibdPncpUwfA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_uo35Yi5lEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_uo35Yy5lEeaF_sH3mLTVKg" key="routing" value="true"/>
       </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_YwvscCpoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_YwvscSpoEeaibdPncpUwfA" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_YwvFYSpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_AFtIUCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YwvFYipoEeaibdPncpUwfA"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQipoEeaibdPncpUwfA" id="(0.102803738317757,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQypoEeaibdPncpUwfA" id="(1.0,0.4864864864864865)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_buPYUCpoEeaibdPncpUwfA" type="4002" source="_l4NucCpnEeaibdPncpUwfA" target="_l4NHaipnEeaibdPncpUwfA" routing="Rectilinear">
       <children xmi:type="notation:DecorationNode" xmi:id="_buPYUypoEeaibdPncpUwfA" visible="false" type="6007">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_buPYVCpoEeaibdPncpUwfA" y="60"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_buPYUSpoEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_CjRW8CpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_buPYUipoEeaibdPncpUwfA" points="[0, 0, 0, -87]$[0, 87, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoCpoEeaibdPncpUwfA" id="(0.4329268292682927,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoSpoEeaibdPncpUwfA" id="(0.5904255319148937,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_buPYUipoEeaibdPncpUwfA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUwuoCpoEeaibdPncpUwfA" id="(0.43783783783783786,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wbiw4C5lEeaF_sH3mLTVKg" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_d0ZMgCpoEeaibdPncpUwfA" type="4002" source="_l4QKsCpnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_buszkC5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_buszkS5TEeaF_sH3mLTVKg" key="routing" value="true"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_d0ZMgypoEeaibdPncpUwfA" visible="false" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_d0ZMhCpoEeaibdPncpUwfA" x="6" y="50"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_d0ZMgSpoEeaibdPncpUwfA"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_VHGfYClvEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d0ZMgipoEeaibdPncpUwfA"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQCpoEeaibdPncpUwfA" id="(0.0,0.41732283464566927)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUZiQSpoEeaibdPncpUwfA" id="(1.0,0.12612612612612611)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Z30KcC5TEeaF_sH3mLTVKg" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_l4KrICpnEeaibdPncpUwfA" routing="Tree">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bule0C5TEeaF_sH3mLTVKg" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bule0S5TEeaF_sH3mLTVKg" key="routing" value="true"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_Z30Kcy5TEeaF_sH3mLTVKg" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_Z30KdC5TEeaF_sH3mLTVKg" y="40"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_Z30KcS5TEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Z3pLUC5TEeaF_sH3mLTVKg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z30Kci5TEeaF_sH3mLTVKg"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z4ECEC5TEeaF_sH3mLTVKg" id="(0.4627659574468085,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z4ECES5TEeaF_sH3mLTVKg" id="(0.5362318840579711,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_x_yvtC5WEeaF_sH3mLTVKg" type="StereotypeCommentLink" source="_x_sCAC5WEeaF_sH3mLTVKg" target="_x_yvsC5WEeaF_sH3mLTVKg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_x_yvtS5WEeaF_sH3mLTVKg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_x_yvuS5WEeaF_sH3mLTVKg" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_EMFGty5nEeaF_sH3mLTVKg" type="StereotypeCommentLink" source="_EL_AEC5nEeaF_sH3mLTVKg" target="_EMFGsy5nEeaF_sH3mLTVKg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EMFGuC5nEeaF_sH3mLTVKg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_EMFGvC5nEeaF_sH3mLTVKg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_x_yvti5WEeaF_sH3mLTVKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_yvty5WEeaF_sH3mLTVKg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_x_yvuC5WEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EMFGuS5nEeaF_sH3mLTVKg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EMFGui5nEeaF_sH3mLTVKg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EMFGuy5nEeaF_sH3mLTVKg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_x__kAC5WEeaF_sH3mLTVKg" type="1013" source="_l4KrICpnEeaibdPncpUwfA" target="_x_sCAC5WEeaF_sH3mLTVKg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_yAALEC5WEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Extension" href="DICE.profile.uml#_uHeZcCpoEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yAALES5WEeaF_sH3mLTVKg" points="[-69, -9, 459, 62]$[-528, -71, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybnJAC5WEeaF_sH3mLTVKg" id="(1.0,0.5765765765765766)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ybnwEC5WEeaF_sH3mLTVKg" id="(0.0,0.36)"/>
+    <edges xmi:type="notation:Connector" xmi:id="_EMQF0C5nEeaF_sH3mLTVKg" type="1013" source="_l4QKsCpnEeaibdPncpUwfA" target="_EL_AEC5nEeaF_sH3mLTVKg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EMQF0S5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_DHOXcC5nEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EMQF0i5nEeaF_sH3mLTVKg" points="[-116, -51, 993, 438]$[-1109, -489, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8mksC5nEeaF_sH3mLTVKg" id="(0.3922413793103448,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8mksS5nEeaF_sH3mLTVKg" id="(0.59,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_EkBFkC5nEeaF_sH3mLTVKg" type="1013" source="_l4L5SypnEeaibdPncpUwfA" target="_EL_AEC5nEeaF_sH3mLTVKg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EkBFkS5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_Qpq6sC5lEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EkBFki5nEeaF_sH3mLTVKg" points="[61, -50, -252, 206]$[282, -231, -31, 25]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8mksi5nEeaF_sH3mLTVKg" id="(0.6212765957446809,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8mksy5nEeaF_sH3mLTVKg" id="(0.35,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GWIjcC5nEeaF_sH3mLTVKg" type="4002" source="_l4IO4CpnEeaibdPncpUwfA" target="_GV9kUC5nEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_GWIjcy5nEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GWIjdC5nEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_GWIjcS5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_hwLz4C5eEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GWIjci5nEeaF_sH3mLTVKg" points="[-23, -71, 138, 426]$[-161, -497, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GkcFMC5nEeaF_sH3mLTVKg" id="(0.4663677130044843,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GkcFMS5nEeaF_sH3mLTVKg" id="(0.49375,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HOQeQC5nEeaF_sH3mLTVKg" type="4002" source="_l4JdACpnEeaibdPncpUwfA" target="_HOE4EC5nEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HOQeQy5nEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HOQeRC5nEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_HOQeQS5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_bSmP8C5fEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HOQeQi5nEeaF_sH3mLTVKg" points="[0, 0, 0, 127]$[0, -127, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HozFMC5nEeaF_sH3mLTVKg" id="(0.42,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HozFMS5nEeaF_sH3mLTVKg" id="(0.41875,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IsJYkC5nEeaF_sH3mLTVKg" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_Ir9LUC5nEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_IsJYky5nEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IsJYlC5nEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_IsJYkS5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_siEzsC5fEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IsJYki5nEeaF_sH3mLTVKg" points="[-74, -63, 491, 426]$[-565, -489, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JIR68C5nEeaF_sH3mLTVKg" id="(0.44680851063829785,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JIR68S5nEeaF_sH3mLTVKg" id="(0.56875,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IshMAC5nEeaF_sH3mLTVKg" type="4002" source="_l4NHaipnEeaibdPncpUwfA" target="_IsQtUC5nEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_IshMAy5nEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IshMBC5nEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_IshMAS5nEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_DlxcAC5kEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IshMAi5nEeaF_sH3mLTVKg" points="[-74, -63, 491, 426]$[-565, -489, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JY6_AC5nEeaF_sH3mLTVKg" id="(0.6117021276595744,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JY6_AS5nEeaF_sH3mLTVKg" id="(0.33,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Lndy0C5qEeaF_sH3mLTVKg" type="4002" source="_l4L5SypnEeaibdPncpUwfA" target="_AFe9YC5qEeaF_sH3mLTVKg">
+      <children xmi:type="notation:DecorationNode" xmi:id="_LneZ4C5qEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_LneZ4S5qEeaF_sH3mLTVKg" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Lndy0S5qEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_LnTawC5qEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lndy0i5qEeaF_sH3mLTVKg" points="[-6, -21, 62, 234]$[-75, -305, -7, -50]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LnwGsC5qEeaF_sH3mLTVKg" id="(0.3617021276595745,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LnwGsS5qEeaF_sH3mLTVKg" id="(0.5649717514124294,1.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_MFeaECpwEeaibdPncpUwfA" type="PapyrusUMLProfileDiagram" name="DTSM::Storm" measurementUnit="Pixel">
@@ -709,7 +825,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGxn7CpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_PGvysCpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGxn4SpwEeaibdPncpUwfA" x="80" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PGxn4SpwEeaibdPncpUwfA" x="209" y="314"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_PlUlECpwEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_PlUlEipwEeaibdPncpUwfA" type="1034"/>
@@ -730,7 +846,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PlVMJCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_PlTW8CpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PlUlESpwEeaibdPncpUwfA" x="318" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PlUlESpwEeaibdPncpUwfA" x="447" y="314"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_QFItkCpwEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_QFItkipwEeaibdPncpUwfA" type="1034"/>
@@ -763,7 +879,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QFJUqSpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_QFHfcCpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QFItkSpwEeaibdPncpUwfA" x="740" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QFItkSpwEeaibdPncpUwfA" x="704" y="315"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Qt1sUCpwEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_Qt1sUipwEeaibdPncpUwfA" type="1034"/>
@@ -792,7 +908,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qt1sXCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Qt0eMCpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qt1sUSpwEeaibdPncpUwfA" x="979" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qt1sUSpwEeaibdPncpUwfA" x="943" y="315"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TItMQCpwEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_TItMQipwEeaibdPncpUwfA" type="1034"/>
@@ -821,7 +937,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TItzVCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_TIr-ICpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TItMQSpwEeaibdPncpUwfA" x="506" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TItMQSpwEeaibdPncpUwfA" x="185" y="580"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TpHxsCpwEeaibdPncpUwfA" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_TpHxsipwEeaibdPncpUwfA" type="1034"/>
@@ -862,9 +978,9 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TpHxvCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_TpGjkCpwEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TpHxsSpwEeaibdPncpUwfA" x="1255" y="336"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TpHxsSpwEeaibdPncpUwfA" x="433" y="578"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_YaLF4CpwEeaibdPncpUwfA" type="1026">
+    <children xmi:type="notation:Shape" xmi:id="_YaLF4CpwEeaibdPncpUwfA" type="1026" fillColor="10265827">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5_SQkCy7EeaXcs4o5Oqmxw" source="QualifiedName">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5_S3oCy7EeaXcs4o5Oqmxw" key="QualifiedNameDepth" value="0"/>
       </eAnnotations>
@@ -882,9 +998,9 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YaLF7CpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_9mn3oCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YaLF4SpwEeaibdPncpUwfA" x="298" y="100"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YaLF4SpwEeaibdPncpUwfA" x="427" y="78"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_YqJbkCpwEeaibdPncpUwfA" type="1026">
+    <children xmi:type="notation:Shape" xmi:id="_YqJbkCpwEeaibdPncpUwfA" type="1026" fillColor="10265827">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5_H4gCy7EeaXcs4o5Oqmxw" source="QualifiedName">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5_H4gSy7EeaXcs4o5Oqmxw" key="QualifiedNameDepth" value="0"/>
       </eAnnotations>
@@ -902,9 +1018,9 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YqJbnCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_8x7EQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YqJbkSpwEeaibdPncpUwfA" x="52" y="105"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YqJbkSpwEeaibdPncpUwfA" x="181" y="83"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_cIULkCpwEeaibdPncpUwfA" type="1026">
+    <children xmi:type="notation:Shape" xmi:id="_cIULkCpwEeaibdPncpUwfA" type="1026" fillColor="10265827">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5_TesCy7EeaXcs4o5Oqmxw" source="QualifiedName">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5_TesSy7EeaXcs4o5Oqmxw" key="QualifiedNameDepth" value="0"/>
       </eAnnotations>
@@ -922,9 +1038,9 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cIUyqipwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_lG6AcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cIULkSpwEeaibdPncpUwfA" x="991" y="99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cIULkSpwEeaibdPncpUwfA" x="955" y="78"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_eiV-ACpwEeaibdPncpUwfA" type="1026">
+    <children xmi:type="notation:Shape" xmi:id="_eiV-ACpwEeaibdPncpUwfA" type="1026" fillColor="10265827">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5_S3oSy7EeaXcs4o5Oqmxw" source="QualifiedName">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5_S3oiy7EeaXcs4o5Oqmxw" key="QualifiedNameDepth" value="0"/>
       </eAnnotations>
@@ -942,7 +1058,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eiV-DCpwEeaibdPncpUwfA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_2HB5kCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eiV-ASpwEeaibdPncpUwfA" x="729" y="102"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eiV-ASpwEeaibdPncpUwfA" x="693" y="81"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_MFeaESpwEeaibdPncpUwfA" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_MFeaEipwEeaibdPncpUwfA"/>
@@ -956,7 +1072,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Z8tPoSpwEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Z8nJACpwEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z8tPoipwEeaibdPncpUwfA" points="[0, 0, -54, 125]$[0, -125, -54, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Z8tPoipwEeaibdPncpUwfA" points="[36, 0, 0, 136]$[36, -136, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z8-8cCpwEeaibdPncpUwfA" id="(0.43902439024390244,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Z8-8cSpwEeaibdPncpUwfA" id="(0.6576576576576577,1.0)"/>
     </edges>
@@ -966,7 +1082,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_aYCgwSpwEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_aX8aICpwEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aYCgwipwEeaibdPncpUwfA" points="[0, 0, -45, 120]$[0, -120, -45, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_aYCgwipwEeaibdPncpUwfA" points="[29, 0, 0, 131]$[29, -131, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aYP8ICpwEeaibdPncpUwfA" id="(0.3567567567567568,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aYP8ISpwEeaibdPncpUwfA" id="(0.6261261261261262,1.0)"/>
     </edges>
@@ -976,7 +1092,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ciHLoSpwEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_ch_P0CpwEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ciHLoipwEeaibdPncpUwfA" points="[0, 0, -51, 126]$[0, -126, -51, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ciHLoipwEeaibdPncpUwfA" points="[0, 0, -45, 137]$[0, -137, -45, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cidw8CpwEeaibdPncpUwfA" id="(0.42913385826771655,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cidw8SpwEeaibdPncpUwfA" id="(0.6666666666666666,1.0)"/>
     </edges>
@@ -986,7 +1102,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_e5U6oSpwEeaibdPncpUwfA"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_e5MXwCpwEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e5U6oipwEeaibdPncpUwfA" points="[0, 0, -52, 123]$[0, -123, -52, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e5U6oipwEeaibdPncpUwfA" points="[0, 0, -42, 134]$[0, -134, -42, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5kyQCpwEeaibdPncpUwfA" id="(0.3853658536585366,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5kyQSpwEeaibdPncpUwfA" id="(0.6396396396396397,1.0)"/>
     </edges>
@@ -1011,7 +1127,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inUVai5MEeaF_sH3mLTVKg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_4a1vQCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inTuUS5MEeaF_sH3mLTVKg" x="82" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inTuUS5MEeaF_sH3mLTVKg" x="515" y="129"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_inZ08C5MEeaF_sH3mLTVKg" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_inZ08i5MEeaF_sH3mLTVKg" type="1034"/>
@@ -1040,7 +1156,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ0_C5MEeaF_sH3mLTVKg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_6kF6wCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ08S5MEeaF_sH3mLTVKg" x="374" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inZ08S5MEeaF_sH3mLTVKg" x="807" y="129"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_infUgC5MEeaF_sH3mLTVKg" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_infUgi5MEeaF_sH3mLTVKg" type="1034"/>
@@ -1065,7 +1181,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUjC5MEeaF_sH3mLTVKg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_CM--wClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUgS5MEeaF_sH3mLTVKg" x="577" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_infUgS5MEeaF_sH3mLTVKg" x="576" y="318"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ink0EC5MEeaF_sH3mLTVKg" type="1026">
       <children xmi:type="notation:DecorationNode" xmi:id="_ink0Ei5MEeaF_sH3mLTVKg" type="1034"/>
@@ -1090,27 +1206,44 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_inlbJC5MEeaF_sH3mLTVKg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Cna4AClvEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ink0ES5MEeaF_sH3mLTVKg" x="778" y="460"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ink0ES5MEeaF_sH3mLTVKg" x="777" y="318"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_xINzAC5MEeaF_sH3mLTVKg" type="1026">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_D5W90C5NEeaF_sH3mLTVKg" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_D5W90S5NEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
+    <children xmi:type="notation:Shape" xmi:id="_FZ9y8C5jEeaF_sH3mLTVKg" type="1026">
+      <children xmi:type="notation:DecorationNode" xmi:id="_FZ9y8i5jEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FZ9y8y5jEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FZ9y9C5jEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FZ9y9S5jEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FZ9y9i5jEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FZ9y9y5jEeaF_sH3mLTVKg"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_FZ9y-C5jEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_FZ9y-S5jEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_FZ9y-i5jEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_FZ9y-y5jEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FZ9y_C5jEeaF_sH3mLTVKg"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_FZ9L4C5jEeaF_sH3mLTVKg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FZ9y8S5jEeaF_sH3mLTVKg" x="110" y="280"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ACXigC5rEeaF_sH3mLTVKg" type="1026" fillColor="8047085">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FA7HMC5rEeaF_sH3mLTVKg" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FA7HMS5rEeaF_sH3mLTVKg" key="QualifiedNameDepth" value="0"/>
       </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_xINzAi5MEeaF_sH3mLTVKg" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xINzAy5MEeaF_sH3mLTVKg" type="1071">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xINzBC5MEeaF_sH3mLTVKg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xINzBS5MEeaF_sH3mLTVKg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xINzBi5MEeaF_sH3mLTVKg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzBy5MEeaF_sH3mLTVKg"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ACXigi5rEeaF_sH3mLTVKg" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ACXigy5rEeaF_sH3mLTVKg" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ACXihC5rEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ACXihS5rEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ACXihi5rEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ACXihy5rEeaF_sH3mLTVKg"/>
       </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xINzCC5MEeaF_sH3mLTVKg" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xINzCS5MEeaF_sH3mLTVKg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xINzCi5MEeaF_sH3mLTVKg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xINzCy5MEeaF_sH3mLTVKg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzDC5MEeaF_sH3mLTVKg"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ACXiiC5rEeaF_sH3mLTVKg" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ACXiiS5rEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ACXiii5rEeaF_sH3mLTVKg"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ACXiiy5rEeaF_sH3mLTVKg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ACXijC5rEeaF_sH3mLTVKg"/>
       </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_uKIUcCluEeaibdPncpUwfA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xINzAS5MEeaF_sH3mLTVKg" x="432" y="217"/>
+      <element xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ACXigS5rEeaF_sH3mLTVKg" x="74" y="64"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Jyg_AS5MEeaF_sH3mLTVKg" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Jyg_Ai5MEeaF_sH3mLTVKg"/>
@@ -1118,45 +1251,15 @@
       <owner xmi:type="uml:Profile" href="DICE.profile.uml#_MPXosOePEeWj7ZPL8JeBTQ"/>
     </styles>
     <element xmi:type="uml:Profile" href="DICE.profile.uml#_lhjuYC5LEeaF_sH3mLTVKg"/>
-    <edges xmi:type="notation:Connector" xmi:id="_xIk_YC5MEeaF_sH3mLTVKg" type="4002" source="_inTuUC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xIlmcC5MEeaF_sH3mLTVKg" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xIlmcS5MEeaF_sH3mLTVKg" y="60"/>
+    <edges xmi:type="notation:Connector" xmi:id="_CxnXAC5rEeaF_sH3mLTVKg" type="4002" source="_FZ9y8C5jEeaF_sH3mLTVKg" target="_ACXigC5rEeaF_sH3mLTVKg" routing="Rectilinear">
+      <children xmi:type="notation:DecorationNode" xmi:id="_CxnXAy5rEeaF_sH3mLTVKg" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CxnXBC5rEeaF_sH3mLTVKg" y="60"/>
       </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_xIk_YS5MEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#__hxU0CpiEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xIk_Yi5MEeaF_sH3mLTVKg" points="[0, 0, -306, -87]$[306, 87, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHLAC5MEeaF_sH3mLTVKg" id="(0.8922413793103449,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6zHLAS5MEeaF_sH3mLTVKg" id="(0.0,0.21)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xtAiIC5MEeaF_sH3mLTVKg" type="4002" source="_inZ08C5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xtAiIy5MEeaF_sH3mLTVKg" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_xtAiJC5MEeaF_sH3mLTVKg" y="60"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_xtAiIS5MEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_G0GS8CpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xtAiIi5MEeaF_sH3mLTVKg" points="[0, 0, -79, -60]$[79, 60, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4_aYwC5MEeaF_sH3mLTVKg" id="(0.6083916083916084,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4_aYwS5MEeaF_sH3mLTVKg" id="(0.29,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_yjuuwC5MEeaF_sH3mLTVKg" type="4002" source="_infUgC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_yjuuwy5MEeaF_sH3mLTVKg" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_yjuuxC5MEeaF_sH3mLTVKg" x="-59" y="-29"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_yjuuwS5MEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_ICAQgCpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yjuuwi5MEeaF_sH3mLTVKg" points="[0, 0, 103, -76]$[-103, 76, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40lBwC5MEeaF_sH3mLTVKg" id="(0.09219858156028368,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_40lBwS5MEeaF_sH3mLTVKg" id="(1.0,0.78)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zOpUAC5MEeaF_sH3mLTVKg" type="4002" source="_ink0EC5MEeaF_sH3mLTVKg" target="_xINzAC5MEeaF_sH3mLTVKg" routing="Tree">
-      <children xmi:type="notation:DecorationNode" xmi:id="_zOpUAy5MEeaF_sH3mLTVKg" type="6007">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zOpUBC5MEeaF_sH3mLTVKg" x="-149" y="-46"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_zOpUAS5MEeaF_sH3mLTVKg"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_JV3sICpjEeaibdPncpUwfA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zOpUAi5MEeaF_sH3mLTVKg" points="[0, 0, 284, -76]$[-284, 76, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4pa6oC5MEeaF_sH3mLTVKg" id="(0.0,0.43243243243243246)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4pa6oS5MEeaF_sH3mLTVKg" id="(1.0,0.17)"/>
+      <styles xmi:type="notation:FontStyle" xmi:id="_CxnXAS5rEeaF_sH3mLTVKg"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_CxkTsC5rEeaF_sH3mLTVKg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CxnXAi5rEeaF_sH3mLTVKg" points="[0, 0, -11, 116]$[0, -116, -11, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxxIAC5rEeaF_sH3mLTVKg" id="(0.66,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CxxIAS5rEeaF_sH3mLTVKg" id="(0.6384180790960452,1.0)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
+++ b/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
@@ -12,7 +12,7 @@
     </packageImport>
     <packagedElement xmi:type="uml:Package" xmi:id="_GCf1wOeaEeWj7ZPL8JeBTQ" name="DICE_UML_Extensions">
       <packagedElement xmi:type="uml:Profile" xmi:id="_gFr1YOebEeWj7ZPL8JeBTQ" name="DPIM">
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_C9h50OejEeWj7ZPL8JeBTQ" name="DiceComponent">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_C9h50OejEeWj7ZPL8JeBTQ" name="DpimComputationNode">
           <generalization xmi:type="uml:Generalization" xmi:id="_VmeK4OejEeWj7ZPL8JeBTQ">
             <general xmi:type="uml:Stereotype" href="pathmap://DAM_PROFILES/DAM.profile.uml#_2vT30OPWEeKfvsJiOXhpew"/>
           </generalization>
@@ -37,7 +37,7 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ncNn8OekEeWj7ZPL8JeBTQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_cx7sAOejEeWj7ZPL8JeBTQ" name="DiceFilterNode">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_cx7sAOejEeWj7ZPL8JeBTQ" name="DpimFilterNode">
           <generalization xmi:type="uml:Generalization" xmi:id="_vBjosOekEeWj7ZPL8JeBTQ" general="_C9h50OejEeWj7ZPL8JeBTQ"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_3uwCUOekEeWj7ZPL8JeBTQ" name="inputRatio">
             <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_UDZSQBFSEdyUJeMeN__D-A"/>
@@ -50,10 +50,10 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5gshEOekEeWj7ZPL8JeBTQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_ffmMIOejEeWj7ZPL8JeBTQ" name="DiceVisualizationNode">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_ffmMIOejEeWj7ZPL8JeBTQ" name="DpimVisualizationNode">
           <generalization xmi:type="uml:Generalization" xmi:id="_wat0AOekEeWj7ZPL8JeBTQ" general="_C9h50OejEeWj7ZPL8JeBTQ"/>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_iCtCEOejEeWj7ZPL8JeBTQ" name="DiceSourceNode">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_iCtCEOejEeWj7ZPL8JeBTQ" name="DpimSourceNode">
           <generalization xmi:type="uml:Generalization" xmi:id="_xT-XQOekEeWj7ZPL8JeBTQ" general="_C9h50OejEeWj7ZPL8JeBTQ"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_Sk0F0OelEeWj7ZPL8JeBTQ" name="store">
             <type xmi:type="uml:DataType" href="DICE_Library.uml#_avs9QOedEeWj7ZPL8JeBTQ"/>
@@ -76,7 +76,7 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XPnBAOelEeWj7ZPL8JeBTQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_kiO_kOejEeWj7ZPL8JeBTQ" name="DiceStorageResource">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_kiO_kOejEeWj7ZPL8JeBTQ" name="DpimStorageNode">
           <generalization xmi:type="uml:Generalization" xmi:id="__26m0OelEeWj7ZPL8JeBTQ">
             <general xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_Sh-rwBGzEdyb1KzJ7GkiGA"/>
           </generalization>
@@ -91,7 +91,7 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Pn3XEOemEeWj7ZPL8JeBTQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_mvdsIOejEeWj7ZPL8JeBTQ" name="DiceChannel">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_mvdsIOejEeWj7ZPL8JeBTQ" name="DpimChannel">
           <generalization xmi:type="uml:Generalization" xmi:id="_XjHWYOemEeWj7ZPL8JeBTQ">
             <general xmi:type="uml:Stereotype" href="pathmap://DAM_PROFILES/DAM.profile.uml#_fdgTgOP9EeKmVK0_L5xJcQ"/>
           </generalization>
@@ -117,7 +117,7 @@
           <elementImport xmi:type="uml:ElementImport" xmi:id="_pnK3ACpoEeaibdPncpUwfA" alias="Class">
             <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
           </elementImport>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_lG6AcCluEeaibdPncpUwfA" name="ComputeNode">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_lG6AcCluEeaibdPncpUwfA" name="CoreComputationNode">
             <generalization xmi:type="uml:Generalization" xmi:id="_Usr0QClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_imBwUCo4EeaibdPncpUwfA" name="processingType">
               <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_udV0QOeXEeWj7ZPL8JeBTQ"/>
@@ -136,10 +136,10 @@
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1wC34CppEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_r1_uoCluEeaibdPncpUwfA" name="DataSource">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_r1_uoCluEeaibdPncpUwfA" name="CoreDataSource">
             <generalization xmi:type="uml:Generalization" xmi:id="_Vhf8YClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_slNlECluEeaibdPncpUwfA" name="StorageNode">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_slNlECluEeaibdPncpUwfA" name="CoreStorageNode">
             <generalization xmi:type="uml:Generalization" xmi:id="_V7slEClvEeaibdPncpUwfA" general="_r1_uoCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_Pn4j8Co7EeaibdPncpUwfA" name="database">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
@@ -151,7 +151,7 @@
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_uKIUcCluEeaibdPncpUwfA" name="DIAElement">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_uKIUcCluEeaibdPncpUwfA" name="DiceDIAElement">
             <ownedAttribute xmi:type="uml:Property" xmi:id="_LO7q8ClwEeaibdPncpUwfA" name="elementId" visibility="public" isReadOnly="true">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             </ownedAttribute>
@@ -161,55 +161,16 @@
             <ownedAttribute xmi:type="uml:Property" xmi:id="_uHfnkCpoEeaibdPncpUwfA" name="base_Class" association="_uHeZcCpoEeaibdPncpUwfA">
               <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
             </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_PewuQCppEeaibdPncpUwfA" name="hasPorperty" type="_v0dIQCluEeaibdPncpUwfA">
-              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U440oCppEeaibdPncpUwfA"/>
-              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U46CwCppEeaibdPncpUwfA" value="*"/>
-            </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_v0dIQCluEeaibdPncpUwfA" name="DICEProperty">
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_bqdMwClxEeaibdPncpUwfA" name="name">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_gbONEClxEeaibdPncpUwfA" name="description">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_9PHncCo7EeaibdPncpUwfA" name="type">
-              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_xeEbQCo7EeaibdPncpUwfA"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_fu_qQCpjEeaibdPncpUwfA" name="propertyId">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_xby5gCluEeaibdPncpUwfA" name="Metric">
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_4GkoEClxEeaibdPncpUwfA" name="metricId" isReadOnly="true">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_6qMbYClxEeaibdPncpUwfA" name="value">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_2HB5kCluEeaibdPncpUwfA" name="DirectAcyclicGraph">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_2HB5kCluEeaibdPncpUwfA" name="CoreDirectAcyclicGraph">
             <generalization xmi:type="uml:Generalization" xmi:id="_AFtIUCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_5tJY4CpkEeaibdPncpUwfA" name="hasSourceNode" type="_9mn3oCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2egq8CpqEeaibdPncpUwfA" value="1"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2eh5ECpqEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_4a1vQCluEeaibdPncpUwfA" name="MapReduceJob">
-            <generalization xmi:type="uml:Generalization" xmi:id="__hxU0CpiEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_OTCFgCpqEeaibdPncpUwfA" name="mapResucePhases" type="_6kF6wCluEeaibdPncpUwfA">
-              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WPQVMCpqEeaibdPncpUwfA" value="1"/>
-              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WPRjUCpqEeaibdPncpUwfA" value="*"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_6kF6wCluEeaibdPncpUwfA" name="MapReducePhase">
-            <generalization xmi:type="uml:Generalization" xmi:id="_G0GS8CpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_6jBpQCpqEeaibdPncpUwfA" name="hasMap" type="_CM--wClvEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_YPsGcCprEeaibdPncpUwfA" name="hasReduce" type="_Cna4AClvEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_1Y3cECprEeaibdPncpUwfA" name="output" type="_KUZx0ClvEeaibdPncpUwfA"/>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_8x7EQCluEeaibdPncpUwfA" name="DAGNode">
-            <generalization xmi:type="uml:Generalization" xmi:id="_D-3yQCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_8x7EQCluEeaibdPncpUwfA" name="CoreDAGNode">
+            <generalization xmi:type="uml:Generalization" xmi:id="_Z3pLUC5TEeaF_sH3mLTVKg" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_6vmJ0CpjEeaibdPncpUwfA" name="parallelism">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             </ownedAttribute>
@@ -221,43 +182,14 @@
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rTfLsCpkEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_9mn3oCluEeaibdPncpUwfA" name="DAGSourceNode">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_9mn3oCluEeaibdPncpUwfA" name="CoreDAGSourceNode">
             <generalization xmi:type="uml:Generalization" xmi:id="_CjRW8CpjEeaibdPncpUwfA" general="_8x7EQCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_IEueQCpsEeaibdPncpUwfA" name="readFrom" type="_r1_uoCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QH5DcCpsEeaibdPncpUwfA" value="1"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QH6RkCpsEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_CM--wClvEeaibdPncpUwfA" name="Map">
-            <generalization xmi:type="uml:Generalization" xmi:id="_ICAQgCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_1jo3kCo9EeaibdPncpUwfA" name="parallelism">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_7t_yICprEeaibdPncpUwfA" name="type">
-              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_AjJ5ICo-EeaibdPncpUwfA"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_Cna4AClvEeaibdPncpUwfA" name="Reduce">
-            <generalization xmi:type="uml:Generalization" xmi:id="_JV3sICpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_zWylgCo9EeaibdPncpUwfA" name="parallelism">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_ABzJoCpsEeaibdPncpUwfA" name="type">
-              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_C5gsgCo-EeaibdPncpUwfA"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_Fc0-4ClvEeaibdPncpUwfA" name="DICEContraint">
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_Ev-_oClyEeaibdPncpUwfA" name="constraintId" isReadOnly="true">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_KoWhMClyEeaibdPncpUwfA" name="threshold">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_CjJfMClzEeaibdPncpUwfA" name="type">
-              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_upZtkClyEeaibdPncpUwfA"/>
-            </ownedAttribute>
-          </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_KUZx0ClvEeaibdPncpUwfA" name="Data">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_KUZx0ClvEeaibdPncpUwfA" name="CoreData">
             <generalization xmi:type="uml:Generalization" xmi:id="_VHGfYClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_F2Tw0CpqEeaibdPncpUwfA" name="location" type="_r1_uoCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Hb_VMCpqEeaibdPncpUwfA" value="1"/>
@@ -270,15 +202,15 @@
               <type xmi:type="uml:DataType" href="DICE_Library.uml#_avs9QOedEeWj7ZPL8JeBTQ"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Extension" xmi:id="_uHeZcCpoEeaibdPncpUwfA" name="E_DIAElement_Class1" memberEnd="_uHfAgCpoEeaibdPncpUwfA _uHfnkCpoEeaibdPncpUwfA">
-            <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_uHfAgCpoEeaibdPncpUwfA" name="extension_DIAElement" type="_uKIUcCluEeaibdPncpUwfA" aggregation="composite" association="_uHeZcCpoEeaibdPncpUwfA"/>
+          <packagedElement xmi:type="uml:Extension" xmi:id="_uHeZcCpoEeaibdPncpUwfA" name="E_DiceDIAElement_Class1" memberEnd="_uHfAgCpoEeaibdPncpUwfA _uHfnkCpoEeaibdPncpUwfA">
+            <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_uHfAgCpoEeaibdPncpUwfA" name="extension_DiceDIAElement" type="_uKIUcCluEeaibdPncpUwfA" aggregation="composite" association="_uHeZcCpoEeaibdPncpUwfA"/>
           </packagedElement>
         </packagedElement>
         <packagedElement xmi:type="uml:Profile" xmi:id="_E-ctACpwEeaibdPncpUwfA" name="Storm">
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_PGvysCpwEeaibdPncpUwfA" name="Bolt">
             <generalization xmi:type="uml:Generalization" xmi:id="_aX8aICpwEeaibdPncpUwfA" general="_8x7EQCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_W9fMgCvQEeaY443vSxM6kg" name="MinTTF">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_W9fMgCvQEeaY443vSxM6kg" name="failure">
+              <type xmi:type="uml:DataType" href="pathmap://DAM_PROFILES/DAM_Library.uml#_yBGBwOPBEeKfhZ42b6AKfg"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_excRACvQEeaY443vSxM6kg" name="d">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
@@ -355,6 +287,39 @@
             </ownedAttribute>
           </packagedElement>
         </packagedElement>
+        <packagedElement xmi:type="uml:Profile" xmi:id="_lhjuYC5LEeaF_sH3mLTVKg" name="Hadoop" URI="">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_4a1vQCluEeaibdPncpUwfA" name="MapReduceJob">
+            <generalization xmi:type="uml:Generalization" xmi:id="__hxU0CpiEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_OTCFgCpqEeaibdPncpUwfA" name="mapResucePhases" type="_6kF6wCluEeaibdPncpUwfA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WPQVMCpqEeaibdPncpUwfA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WPRjUCpqEeaibdPncpUwfA" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_6kF6wCluEeaibdPncpUwfA" name="MapReducePhase">
+            <generalization xmi:type="uml:Generalization" xmi:id="_G0GS8CpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_6jBpQCpqEeaibdPncpUwfA" name="hasMap" type="_CM--wClvEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_YPsGcCprEeaibdPncpUwfA" name="hasReduce" type="_Cna4AClvEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_1Y3cECprEeaibdPncpUwfA" name="output" type="_KUZx0ClvEeaibdPncpUwfA"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_CM--wClvEeaibdPncpUwfA" name="Map">
+            <generalization xmi:type="uml:Generalization" xmi:id="_ICAQgCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_1jo3kCo9EeaibdPncpUwfA" name="parallelism">
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_7t_yICprEeaibdPncpUwfA" name="type">
+              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_AjJ5ICo-EeaibdPncpUwfA"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_Cna4AClvEeaibdPncpUwfA" name="Reduce">
+            <generalization xmi:type="uml:Generalization" xmi:id="_JV3sICpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_zWylgCo9EeaibdPncpUwfA" name="parallelism">
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ABzJoCpsEeaibdPncpUwfA" name="type">
+              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_C5gsgCo-EeaibdPncpUwfA"/>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
         <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_B66nMCy4EeagadxR5JgrcA">
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B671UCy4EeagadxR5JgrcA" source="http://www.eclipse.org/uml2/2.0.0/UML">
             <references xmi:type="ecore:EPackage" href="pathmap://UML_PROFILES/Ecore.profile.uml#_z1OFcHjqEdy8S4Cr8Rc_NA"/>
@@ -382,4 +347,5 @@
   <Ecore:EPackage xmi:id="_Q9gCMCluEeaibdPncpUwfA" base_Package="_Q9bJsCluEeaibdPncpUwfA" packageName="Core" nsPrefix="Core" nsURI="http://es.unizar.disco.dice/profiles/DTSM/Core/1.0" basePackage="es.unizar.disco.dice.dtsm"/>
   <Ecore:EPackage xmi:id="_E-izoCpwEeaibdPncpUwfA" base_Package="_E-ctACpwEeaibdPncpUwfA" packageName="Storm" nsPrefix="Storm" nsURI="http://es.unizar.disco.dice/profiles/DTSM/Storm/1.0" basePackage="es.unizar.disco.dice.dtsm"/>
   <Ecore:EPackage xmi:id="_CfCn8Cy4EeagadxR5JgrcA" base_Package="__nIcICy2EeagadxR5JgrcA" packageName="DTSM" nsPrefix="DTSM" nsURI="http://es.unizar.disco.dice/profiles/DTSM/1.0" basePackage="es.unizar.disco.dice"/>
+  <Ecore:EPackage xmi:id="_0yQ4UC5LEeaF_sH3mLTVKg" base_Package="_lhjuYC5LEeaF_sH3mLTVKg" packageName="Hadoop" nsPrefix="Hadoop" nsURI="http://es.unizar.disco.dice/profiles/DTSM/Hadoop/1.0" basePackage="es.unizar.disco.dice.dtsm"/>
 </xmi:XMI>

--- a/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
+++ b/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
@@ -111,6 +111,11 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eWiyAOemEeWj7ZPL8JeBTQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_xjoMkC5gEeaF_sH3mLTVKg" name="DpimScenario">
+          <generalization xmi:type="uml:Generalization" xmi:id="_70CFYC5gEeaF_sH3mLTVKg">
+            <general xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+          </generalization>
+        </packagedElement>
       </packagedElement>
       <packagedElement xmi:type="uml:Package" xmi:id="__nIcICy2EeagadxR5JgrcA" name="DTSM">
         <packagedElement xmi:type="uml:Package" xmi:id="_Q9bJsCluEeaibdPncpUwfA" name="Core" metaclassReference="_pnK3ACpoEeaibdPncpUwfA">
@@ -118,10 +123,7 @@
             <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
           </elementImport>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_lG6AcCluEeaibdPncpUwfA" name="CoreComputationNode">
-            <generalization xmi:type="uml:Generalization" xmi:id="_Usr0QClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_imBwUCo4EeaibdPncpUwfA" name="processingType">
-              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_udV0QOeXEeWj7ZPL8JeBTQ"/>
-            </ownedAttribute>
+            <generalization xmi:type="uml:Generalization" xmi:id="_hwLz4C5eEeaF_sH3mLTVKg" general="_C9h50OejEeWj7ZPL8JeBTQ"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_oWUlECpmEeaibdPncpUwfA" name="hasSuccessor" type="_lG6AcCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qSL00CpmEeaibdPncpUwfA"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qSNC8CpmEeaibdPncpUwfA" value="*"/>
@@ -137,7 +139,7 @@
             </ownedAttribute>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_r1_uoCluEeaibdPncpUwfA" name="CoreDataSource">
-            <generalization xmi:type="uml:Generalization" xmi:id="_Vhf8YClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_bSmP8C5fEeaF_sH3mLTVKg" general="_kiO_kOejEeWj7ZPL8JeBTQ"/>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_slNlECluEeaibdPncpUwfA" name="CoreStorageNode">
             <generalization xmi:type="uml:Generalization" xmi:id="_V7slEClvEeaibdPncpUwfA" general="_r1_uoCluEeaibdPncpUwfA"/>
@@ -151,26 +153,23 @@
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_uKIUcCluEeaibdPncpUwfA" name="DiceDIAElement">
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_LO7q8ClwEeaibdPncpUwfA" name="elementId" visibility="public" isReadOnly="true">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_jOHA4ClwEeaibdPncpUwfA" name="description">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            </ownedAttribute>
-            <ownedAttribute xmi:type="uml:Property" xmi:id="_uHfnkCpoEeaibdPncpUwfA" name="base_Class" association="_uHeZcCpoEeaibdPncpUwfA">
-              <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-            </ownedAttribute>
-          </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_2HB5kCluEeaibdPncpUwfA" name="CoreDirectAcyclicGraph">
-            <generalization xmi:type="uml:Generalization" xmi:id="_AFtIUCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_LnTawC5qEeaF_sH3mLTVKg">
+              <general xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+            </generalization>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_5tJY4CpkEeaibdPncpUwfA" name="hasSourceNode" type="_9mn3oCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2egq8CpqEeaibdPncpUwfA" value="1"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2eh5ECpqEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_QpsI0S5lEeaF_sH3mLTVKg" name="base_Class" association="_Qpq6sC5lEeaF_sH3mLTVKg">
+              <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+            </ownedAttribute>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_8x7EQCluEeaibdPncpUwfA" name="CoreDAGNode">
-            <generalization xmi:type="uml:Generalization" xmi:id="_Z3pLUC5TEeaF_sH3mLTVKg" general="_uKIUcCluEeaibdPncpUwfA"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_siEzsC5fEeaF_sH3mLTVKg" general="_iCtCEOejEeWj7ZPL8JeBTQ"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_DlxcAC5kEeaF_sH3mLTVKg">
+              <general xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_eXMtwBKZEdyGYuetzx6T5A"/>
+            </generalization>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_6vmJ0CpjEeaibdPncpUwfA" name="parallelism">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             </ownedAttribute>
@@ -190,7 +189,6 @@
             </ownedAttribute>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_KUZx0ClvEeaibdPncpUwfA" name="CoreData">
-            <generalization xmi:type="uml:Generalization" xmi:id="_VHGfYClvEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_F2Tw0CpqEeaibdPncpUwfA" name="location" type="_r1_uoCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Hb_VMCpqEeaibdPncpUwfA" value="1"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Hb_8QCpqEeaibdPncpUwfA" value="*"/>
@@ -201,40 +199,46 @@
             <ownedAttribute xmi:type="uml:Property" xmi:id="_OcLdoCpuEeaibdPncpUwfA" name="hasVolume">
               <type xmi:type="uml:DataType" href="DICE_Library.uml#_avs9QOedEeWj7ZPL8JeBTQ"/>
             </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_DHOXci5nEeaF_sH3mLTVKg" name="base_Class" association="_DHOXcC5nEeaF_sH3mLTVKg">
+              <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+            </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Extension" xmi:id="_uHeZcCpoEeaibdPncpUwfA" name="E_DiceDIAElement_Class1" memberEnd="_uHfAgCpoEeaibdPncpUwfA _uHfnkCpoEeaibdPncpUwfA">
-            <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_uHfAgCpoEeaibdPncpUwfA" name="extension_DiceDIAElement" type="_uKIUcCluEeaibdPncpUwfA" aggregation="composite" association="_uHeZcCpoEeaibdPncpUwfA"/>
+          <packagedElement xmi:type="uml:Extension" xmi:id="_Qpq6sC5lEeaF_sH3mLTVKg" name="E_CoreDirectAcyclicGraph_Class1" memberEnd="_QpsI0C5lEeaF_sH3mLTVKg _QpsI0S5lEeaF_sH3mLTVKg">
+            <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_QpsI0C5lEeaF_sH3mLTVKg" name="extension_CoreDirectAcyclicGraph" type="_2HB5kCluEeaibdPncpUwfA" aggregation="composite" association="_Qpq6sC5lEeaF_sH3mLTVKg"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Extension" xmi:id="_DHOXcC5nEeaF_sH3mLTVKg" name="E_CoreData_Class1" memberEnd="_DHOXcS5nEeaF_sH3mLTVKg _DHOXci5nEeaF_sH3mLTVKg">
+            <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_DHOXcS5nEeaF_sH3mLTVKg" name="extension_CoreData" type="_KUZx0ClvEeaibdPncpUwfA" aggregation="composite" association="_DHOXcC5nEeaF_sH3mLTVKg"/>
           </packagedElement>
         </packagedElement>
         <packagedElement xmi:type="uml:Profile" xmi:id="_E-ctACpwEeaibdPncpUwfA" name="Storm">
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_PGvysCpwEeaibdPncpUwfA" name="Bolt">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_PGvysCpwEeaibdPncpUwfA" name="StormBolt">
             <generalization xmi:type="uml:Generalization" xmi:id="_aX8aICpwEeaibdPncpUwfA" general="_8x7EQCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_W9fMgCvQEeaY443vSxM6kg" name="failure">
               <type xmi:type="uml:DataType" href="pathmap://DAM_PROFILES/DAM_Library.uml#_yBGBwOPBEeKfhZ42b6AKfg"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_excRACvQEeaY443vSxM6kg" name="d">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_hItDUCvQEeaY443vSxM6kg" name="alpha">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_jRG6QCvQEeaY443vSxM6kg" name="sigma">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_lvlu4CvQEeaY443vSxM6kg" name="minRebootTime">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_owhwUCvQEeaY443vSxM6kg" name="maxRebootTime">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_PlTW8CpwEeaibdPncpUwfA" name="Spout">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_PlTW8CpwEeaibdPncpUwfA" name="StormSpout">
             <generalization xmi:type="uml:Generalization" xmi:id="_Z8nJACpwEeaibdPncpUwfA" general="_9mn3oCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_tZ4hECvQEeaY443vSxM6kg" name="avgEmitRate">
-              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_METAMODELS/Ecore.metamodel.uml#EFloat"/>
+              <type xmi:type="uml:DataType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_Yq-MQBFQEdyUJeMeN__D-A"/>
             </ownedAttribute>
           </packagedElement>
-          <packagedElement xmi:type="uml:Stereotype" xmi:id="_QFHfcCpwEeaibdPncpUwfA" name="Topology">
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_QFHfcCpwEeaibdPncpUwfA" name="StormScenarioTopology">
             <generalization xmi:type="uml:Generalization" xmi:id="_e5MXwCpwEeaibdPncpUwfA" general="_2HB5kCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_wZ1rECvQEeaY443vSxM6kg" name="queueThreshold">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
@@ -289,20 +293,17 @@
         </packagedElement>
         <packagedElement xmi:type="uml:Profile" xmi:id="_lhjuYC5LEeaF_sH3mLTVKg" name="Hadoop" URI="">
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_4a1vQCluEeaibdPncpUwfA" name="MapReduceJob">
-            <generalization xmi:type="uml:Generalization" xmi:id="__hxU0CpiEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_OTCFgCpqEeaibdPncpUwfA" name="mapResucePhases" type="_6kF6wCluEeaibdPncpUwfA">
               <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WPQVMCpqEeaibdPncpUwfA" value="1"/>
               <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WPRjUCpqEeaibdPncpUwfA" value="*"/>
             </ownedAttribute>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_6kF6wCluEeaibdPncpUwfA" name="MapReducePhase">
-            <generalization xmi:type="uml:Generalization" xmi:id="_G0GS8CpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_6jBpQCpqEeaibdPncpUwfA" name="hasMap" type="_CM--wClvEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_YPsGcCprEeaibdPncpUwfA" name="hasReduce" type="_Cna4AClvEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_1Y3cECprEeaibdPncpUwfA" name="output" type="_KUZx0ClvEeaibdPncpUwfA"/>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_CM--wClvEeaibdPncpUwfA" name="Map">
-            <generalization xmi:type="uml:Generalization" xmi:id="_ICAQgCpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_1jo3kCo9EeaibdPncpUwfA" name="parallelism">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             </ownedAttribute>
@@ -311,13 +312,17 @@
             </ownedAttribute>
           </packagedElement>
           <packagedElement xmi:type="uml:Stereotype" xmi:id="_Cna4AClvEeaibdPncpUwfA" name="Reduce">
-            <generalization xmi:type="uml:Generalization" xmi:id="_JV3sICpjEeaibdPncpUwfA" general="_uKIUcCluEeaibdPncpUwfA"/>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_zWylgCo9EeaibdPncpUwfA" name="parallelism">
               <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             </ownedAttribute>
             <ownedAttribute xmi:type="uml:Property" xmi:id="_ABzJoCpsEeaibdPncpUwfA" name="type">
               <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_C5gsgCo-EeaibdPncpUwfA"/>
             </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Stereotype" xmi:id="_FZ9L4C5jEeaF_sH3mLTVKg" name="HadoopScenario">
+            <generalization xmi:type="uml:Generalization" xmi:id="_CxkTsC5rEeaF_sH3mLTVKg">
+              <general xmi:type="uml:Stereotype" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_XYaMIBKYEdyGYuetzx6T5A"/>
+            </generalization>
           </packagedElement>
         </packagedElement>
         <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_B66nMCy4EeagadxR5JgrcA">

--- a/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
+++ b/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
@@ -220,28 +220,6 @@
               <element xmi:type="uml:Enumeration" href="DICE_Library.uml#_upZtkClyEeaibdPncpUwfA"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p5dWISyzEeagadxR5JgrcA" x="184" y="243"/>
             </children>
-            <children xmi:type="notation:Shape" xmi:id="_p6a_cCyzEeagadxR5JgrcA" type="3025">
-              <children xmi:type="notation:DecorationNode" xmi:id="_p6a_ciyzEeagadxR5JgrcA" type="5055"/>
-              <children xmi:type="notation:DecorationNode" xmi:id="_p6a_cyyzEeagadxR5JgrcA" type="8516">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_p6a_dCyzEeagadxR5JgrcA" y="5"/>
-              </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_p6bmgCyzEeagadxR5JgrcA" type="7031">
-                <children xmi:type="notation:Shape" xmi:id="_ut3gUCyzEeagadxR5JgrcA" type="3017">
-                  <element xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_0OTHMCo7EeaibdPncpUwfA"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_ut3gUSyzEeagadxR5JgrcA"/>
-                </children>
-                <children xmi:type="notation:Shape" xmi:id="_uuX2oCyzEeagadxR5JgrcA" type="3017">
-                  <element xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_4iKJECo7EeaibdPncpUwfA"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uuX2oSyzEeagadxR5JgrcA"/>
-                </children>
-                <styles xmi:type="notation:TitleStyle" xmi:id="_p6bmgSyzEeagadxR5JgrcA"/>
-                <styles xmi:type="notation:SortingStyle" xmi:id="_p6bmgiyzEeagadxR5JgrcA"/>
-                <styles xmi:type="notation:FilteringStyle" xmi:id="_p6bmgyyzEeagadxR5JgrcA"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p6bmhCyzEeagadxR5JgrcA"/>
-              </children>
-              <element xmi:type="uml:Enumeration" href="DICE_Library.uml#_xeEbQCo7EeaibdPncpUwfA"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p6a_cSyzEeagadxR5JgrcA" x="310" y="244"/>
-            </children>
             <children xmi:type="notation:Shape" xmi:id="_p7Z24CyzEeagadxR5JgrcA" type="3025">
               <children xmi:type="notation:DecorationNode" xmi:id="_p7Z24iyzEeagadxR5JgrcA" type="5055"/>
               <children xmi:type="notation:DecorationNode" xmi:id="_p7Z24yyzEeagadxR5JgrcA" type="8516">
@@ -389,11 +367,39 @@
         <children xmi:type="notation:Shape" xmi:id="_yQp4YOeYEeWj7ZPL8JeBTQ" type="3009" fillColor="14012867">
           <children xmi:type="notation:DecorationNode" xmi:id="_yQqfceeYEeWj7ZPL8JeBTQ" type="5017"/>
           <children xmi:type="notation:BasicCompartment" xmi:id="_yQqfcueYEeWj7ZPL8JeBTQ" type="7010">
+            <children xmi:type="notation:Shape" xmi:id="_KyK2cC5SEeaF_sH3mLTVKg" type="3027">
+              <children xmi:type="notation:DecorationNode" xmi:id="_KyK2ci5SEeaF_sH3mLTVKg" type="5061"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_KyK2cy5SEeaF_sH3mLTVKg" type="8520">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_KyK2dC5SEeaF_sH3mLTVKg" y="5"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_KyK2dS5SEeaF_sH3mLTVKg" type="7032">
+                <children xmi:type="notation:Shape" xmi:id="_pbVYIC5SEeaF_sH3mLTVKg" type="3018">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_pbLAEC5SEeaF_sH3mLTVKg"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_pbVYIS5SEeaF_sH3mLTVKg"/>
+                </children>
+                <children xmi:type="notation:Shape" xmi:id="_25ZfwC5SEeaF_sH3mLTVKg" type="3018">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_25PuwC5SEeaF_sH3mLTVKg"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_25ZfwS5SEeaF_sH3mLTVKg"/>
+                </children>
+                <styles xmi:type="notation:TitleStyle" xmi:id="_KyK2di5SEeaF_sH3mLTVKg"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_KyK2dy5SEeaF_sH3mLTVKg"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_KyK2eC5SEeaF_sH3mLTVKg"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyK2eS5SEeaF_sH3mLTVKg"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_KyLdgC5SEeaF_sH3mLTVKg" type="7033">
+                <styles xmi:type="notation:TitleStyle" xmi:id="_KyLdgS5SEeaF_sH3mLTVKg"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_KyLdgi5SEeaF_sH3mLTVKg"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_KyLdgy5SEeaF_sH3mLTVKg"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyLdhC5SEeaF_sH3mLTVKg"/>
+              </children>
+              <element xmi:type="uml:DataType" href="DICE_Library.uml#_KyBsgC5SEeaF_sH3mLTVKg"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KyK2cS5SEeaF_sH3mLTVKg" x="22" y="19"/>
+            </children>
             <styles xmi:type="notation:TitleStyle" xmi:id="_yQqfc-eYEeWj7ZPL8JeBTQ"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yQqfdOeYEeWj7ZPL8JeBTQ"/>
           </children>
           <element xmi:type="uml:Package" href="DICE_Library.uml#_yQjxwOeYEeWj7ZPL8JeBTQ"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yQqfcOeYEeWj7ZPL8JeBTQ" x="10" y="517" width="787" height="135"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yQqfcOeYEeWj7ZPL8JeBTQ" x="11" y="509" width="787" height="178"/>
         </children>
         <children xmi:type="notation:Shape" xmi:id="_vw8p4OeaEeWj7ZPL8JeBTQ" type="StereotypeComment">
           <styles xmi:type="notation:TitleStyle" xmi:id="_vw8p4eeaEeWj7ZPL8JeBTQ" showTitle="true"/>

--- a/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
+++ b/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
@@ -49,10 +49,6 @@
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_91ZWoClyEeaibdPncpUwfA" name="GreaterEqual"/>
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_98IQwClyEeaibdPncpUwfA" name="Greater"/>
         </packagedElement>
-        <packagedElement xmi:type="uml:Enumeration" xmi:id="_xeEbQCo7EeaibdPncpUwfA" name="DICEProperty">
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_0OTHMCo7EeaibdPncpUwfA" name="DataQualityLevel"/>
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4iKJECo7EeaibdPncpUwfA" name="PrivacyLevel"/>
-        </packagedElement>
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_-pTbkCo9EeaibdPncpUwfA" name="WorkflowOperation">
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_35al4CpuEeaibdPncpUwfA" name="GroupBy"/>
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4LmiECpuEeaibdPncpUwfA" name="Sum"/>
@@ -70,7 +66,16 @@
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vC4DACpuEeaibdPncpUwfA" name="IntSumReducer"/>
         </packagedElement>
       </packagedElement>
-      <packagedElement xmi:type="uml:Package" xmi:id="_yQjxwOeYEeWj7ZPL8JeBTQ" name="Data_Types"/>
+      <packagedElement xmi:type="uml:Package" xmi:id="_yQjxwOeYEeWj7ZPL8JeBTQ" name="Data_Types">
+        <packagedElement xmi:type="uml:DataType" xmi:id="_KyBsgC5SEeaF_sH3mLTVKg" name="NFP_Privacy">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_pbLAEC5SEeaF_sH3mLTVKg" name="expr">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_bManMBEBEdyx6M3BlUjlCQ"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_25PuwC5SEeaF_sH3mLTVKg" name="source">
+            <type xmi:type="uml:Enumeration" href="pathmap://Papyrus_PROFILES/MARTE_Library.library.uml#_oMZzEBD-EdyybZnLxHsjyA"/>
+          </ownedAttribute>
+        </packagedElement>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_8J84wOeYEeWj7ZPL8JeBTQ" name="Complex_DICE_Types">
       <packagedElement xmi:type="uml:Package" xmi:id="_GunKUOeZEeWj7ZPL8JeBTQ" name="Data_Types">


### PR DESCRIPTION
# List of changes:
1. We have changed the prefixes of the stereotypes according to the MARTE/DAM guidelines as follows:
   - Dpim\* for the DPIM Profile;
   - Core\* for DTSM::Core;
   - Storm\* for DTSM::Storm
2. We have reverted the changes on some names as you wanted (e.g., `ComputationNode`, `StorageNode`)
3. We have created the `DTSM::Hadoop` package. It contains some tentative stereotypes.
4. We have moved stereotypes (`MapReduceJob`, `MapReducePhase`, `Map` and `Reduce`) from `DTSM::Core` to `DTSM::Hadoop` 
5. We have removed `DTSM::Core::Metric` stereotype since:
   - It is not used in the current Profiles definition;
   - Metrics should be defined as stereotype’s tags of type NFP_\* (e.g. NFP_Real, NFP_Frequency, NFP_Duration, etc.), and with `source=calc`  as proposed by MARTE.
6. We have removed `DTSM::Core::DICEConstraint` stereotype for the same reasons:
   - It is not used in the current Profiles definition;
   - Metrics should be defined as stereotype’s tags of type NFP_\* (e.g. NFP_Real, NFP_Frequency, NFP_Duration, etc.), and with `source=req`  as proposed by MARTE.
7. We have changed `DTSM::Storm::Bolt.MinTTF` to `DTSM::Storm::Bolt.failure` with type `DaFailure` which allows the complete definition of a failure including the MTTF.
8. We have deleted `DTSM::Core::DIAElement.hasProperty` since properties need to be defined as stereotype’s tags (see previous example, `DTSM::Storm::Bolt.failure`).
9. We have deleted `DTSM::Core::DICEProperty` and `DICE_Library::Basic_DICE_Types::Enumeration_Types::DICEProperty` since: 
   - It is useful for defining either Privacy or Quality properties, but the latter need to be defined as explained before in 5, 6 and 7
   - We have deleted the tag using it, see 8. Therefore for Privacy properties definition we need to provide a mechanism similar to the one for defining Quality properties. We have created a `DICE::NFP_Privacy` type similar to `MARTE::MARTE_Library::NFP_CommonType`.
10. We have deleted `DTSM::Core::DiaElement` because: 
    - It is an abstract class in the metamodel
    - The attribute elementID is really the name of the element, while the description seems not to be a specific concept of the DIA. 
