### PR TITLE
new groupings for storm streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/target/

--- a/bundles/com.masdes.dam.static.profile.ui/META-INF/MANIFEST.MF
+++ b/bundles/com.masdes.dam.static.profile.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.masdes.dam.static.profile.ui;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: com.masdes.dam.profile.ui.DAMEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/com.masdes.dam.static.profile/META-INF/MANIFEST.MF
+++ b/bundles/com.masdes.dam.static.profile/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.masdes.dam.static.profile;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/es.unizar.disco.dice.static.profile/META-INF/MANIFEST.MF
+++ b/bundles/es.unizar.disco.dice.static.profile/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: es.unizar.disco.dice.static.profile;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.uml2.uml/.gitignore
+++ b/bundles/org.eclipse.uml2.uml/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/target/

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>es.unizar.profiles</groupId>
         <artifactId>es.unizar.profiles.root</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/bundles/ro.ieat.secureuml.profile/META-INF/MANIFEST.MF
+++ b/bundles/ro.ieat.secureuml.profile/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ro.ieat.secureuml.profile;singleton:=true
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/features/com.masdes.dam.profile.feature/feature.xml
+++ b/features/com.masdes.dam.profile.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.masdes.dam.profile.feature"
       label="DICE DAM Profile"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="DisCo - Unizar">
 
    <description url="https://github.com/dice-project/DICE-Profiles">
@@ -236,7 +236,7 @@ any resulting litigation.
          id="com.masdes.dam.static.profile"
          download-size="0"
          install-size="0"
-         version="0.9.0.qualifier"
+         version="0.10.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/features/com.masdes.dam.profile.ui.feature/feature.xml
+++ b/features/com.masdes.dam.profile.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.masdes.dam.profile.ui.feature"
       label="DICE DAM Profile UI Enhancements"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="DisCo - Unizar">
 
    <description url="https://github.com/dice-project/DICE-Profiles">
@@ -246,7 +246,7 @@ any resulting litigation.
          id="com.masdes.dam.static.profile.ui"
          download-size="0"
          install-size="0"
-         version="0.9.0.qualifier"
+         version="0.10.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/features/es.unizar.disco.dice.feature/feature.xml
+++ b/features/es.unizar.disco.dice.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="es.unizar.disco.dice.profile.feature"
       label="DICE Profile"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="DisCo - Unizar">
 
    <description url="https://github.com/dice-project/DICE-Profiles">
@@ -236,7 +236,7 @@ any resulting litigation.
          id="es.unizar.disco.dice.static.profile"
          download-size="0"
          install-size="0"
-         version="0.9.0.qualifier"
+         version="0.10.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -8,7 +8,7 @@
         <parent>
                 <groupId>es.unizar.profiles</groupId>
                 <artifactId>es.unizar.profiles.root</artifactId>
-                <version>0.9.0-SNAPSHOT</version>
+                <version>0.10.0-SNAPSHOT</version>
                 <relativePath>../pom.xml</relativePath>
         </parent>
 

--- a/features/ro.ieat.secureuml.profile.feature/feature.xml
+++ b/features/ro.ieat.secureuml.profile.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ro.ieat.secureuml.profile.feature"
       label="Secure UML profile"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="IEAT">
 
    <description url="https://github.com/dice-project/DICE-Profiles">
@@ -231,7 +231,7 @@ any resulting litigation.
          id="ro.ieat.secureuml.profile"
          download-size="0"
          install-size="0"
-         version="0.9.0.qualifier"
+         version="0.10.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
  <parent>
    <groupId>es.unizar.profiles</groupId>
    <artifactId>es.unizar.profiles.configuration</artifactId>
-   <version>0.9.0-SNAPSHOT</version>
+   <version>0.10.0-SNAPSHOT</version>
   <relativePath>.\releng\es.unizar.profiles.configuration</relativePath>
  </parent>
 

--- a/releng/es.unizar.profiles.configuration/pom.xml
+++ b/releng/es.unizar.profiles.configuration/pom.xml
@@ -3,14 +3,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>es.unizar.profiles</groupId>
 	<artifactId>es.unizar.profiles.configuration</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.10.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>
 		<tycho.version>0.25.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<neon-repo.url>http://download.eclipse.org/releases/neon</neon-repo.url>
-		<project.version>0.9.0-SNAPSHOT</project.version>
+		<project.version>0.10.0-SNAPSHOT</project.version>
 	</properties>
 
 	<repositories>

--- a/releng/es.unizar.profiles.update/category.xml
+++ b/releng/es.unizar.profiles.update/category.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.masdes.dam.profile.feature_0.9.0.qualifier.jar" id="com.masdes.dam.profile.feature" version="0.9.0.qualifier">
+   <feature url="features/com.masdes.dam.profile.feature_0.10.0.qualifier.jar" id="com.masdes.dam.profile.feature" version="0.10.0.qualifier">
       <category name="Profiles"/>
    </feature>
-   <feature url="features/com.masdes.dam.profile.ui.feature_0.9.0.qualifier.jar" id="com.masdes.dam.profile.ui.feature" version="0.9.0.qualifier">
+   <feature url="features/com.masdes.dam.profile.ui.feature_0.10.0.qualifier.jar" id="com.masdes.dam.profile.ui.feature" version="0.10.0.qualifier">
       <category name="Profiles"/>
    </feature>
-   <feature url="features/es.unizar.disco.dice.profile.feature_0.9.0.qualifier.jar" id="es.unizar.disco.dice.profile.feature" version="0.9.0.qualifier">
+   <feature url="features/es.unizar.disco.dice.profile.feature_0.10.0.qualifier.jar" id="es.unizar.disco.dice.profile.feature" version="0.10.0.qualifier">
       <category name="Profiles"/>
    </feature>
-   <feature url="features/ro.ieat.secureuml.profile.feature_0.9.0.qualifier.jar" id="ro.ieat.secureuml.profile.feature" version="0.9.0.qualifier">
+   <feature url="features/ro.ieat.secureuml.profile.feature_0.10.0.qualifier.jar" id="ro.ieat.secureuml.profile.feature" version="0.10.0.qualifier">
       <category name="Profiles"/>
    </feature>
    <category-def name="Profiles" label="Profiles"/>

--- a/releng/es.unizar.profiles.update/pom.xml
+++ b/releng/es.unizar.profiles.update/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>es.unizar.profiles</groupId>
 		<artifactId>es.unizar.profiles.releng</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -8,7 +8,7 @@
         <parent>
                 <groupId>es.unizar.profiles</groupId>
                 <artifactId>es.unizar.profiles.root</artifactId>
-                <version>0.9.0-SNAPSHOT</version>
+                <version>0.10.0-SNAPSHOT</version>
                 <relativePath>../pom.xml</relativePath>
         </parent>
 

--- a/tests/es.unizar.disco.dice.static.profile.tests/META-INF/MANIFEST.MF
+++ b/tests/es.unizar.disco.dice.static.profile.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: es.unizar.disco.dice.static.profile.tests
-Bundle-Version: 0.9.0.qualifier
-Fragment-Host: es.unizar.disco.dice.static.profile;bundle-version="0.9.0"
+Bundle-Version: 0.10.0.qualifier
+Fragment-Host: es.unizar.disco.dice.static.profile;bundle-version="0.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/tests/es.unizar.disco.dice.static.profile.tests/pom.xml
+++ b/tests/es.unizar.disco.dice.static.profile.tests/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>es.unizar.profiles</groupId>
 		<artifactId>es.unizar.profiles.tests</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -8,7 +8,7 @@
         <parent>
                 <groupId>es.unizar.profiles</groupId>
                 <artifactId>es.unizar.profiles.root</artifactId>
-                <version>0.9.0-SNAPSHOT</version>
+                <version>0.10.0-SNAPSHOT</version>
                 <relativePath>../pom.xml</relativePath>
         </parent>
 


### PR DESCRIPTION
This PR modifies the storm profile to add new groupings for streams. 

There is also an increment the version number: version 0.3.5 of the DICE simulation tool requires this version of Profiles. 