### PR TITLE
Fixing DDSM profile in preparation of TOSCA blueprints  generation from UML models.

### DIFF
--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
@@ -1679,7 +1679,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Uz43qjx3EeaOH59TuV453g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Uz1NQDx3EeaOH59TuV453g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Uz4QkTx3EeaOH59TuV453g" x="1335" y="313"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Uz4QkTx3EeaOH59TuV453g" x="233" y="712"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_VW7TQDx3EeaOH59TuV453g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_VW7TQjx3EeaOH59TuV453g" type="Stereotype_NameLabel"/>
@@ -1696,6 +1696,18 @@
           <element xmi:type="uml:Property" href="DICE.profile.uml#_eLU0sIlxEeaFpJw9Inr05g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_eLpk0YlxEeaFpJw9Inr05g"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_ira9kP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_iqnFQP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ira9kf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_myFQ8P5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_mxpMEP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_myFQ8f5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_n3WP4P5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_n26yEP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_n3WP4f5mEeastMYiWd95zQ"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_VW7TRDx3EeaOH59TuV453g"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_VW7TRTx3EeaOH59TuV453g"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_VW7TRjx3EeaOH59TuV453g"/>
@@ -1708,7 +1720,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VW7TTDx3EeaOH59TuV453g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_VW6FIDx3EeaOH59TuV453g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VW7TQTx3EeaOH59TuV453g" x="251" y="380"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VW7TQTx3EeaOH59TuV453g" x="574" y="712"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_2gU9EDx3EeaOH59TuV453g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_2gU9Ejx3EeaOH59TuV453g" type="Stereotype_NameLabel"/>
@@ -1729,7 +1741,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2gU9HDx3EeaOH59TuV453g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_2gRSsDx3EeaOH59TuV453g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2gU9ETx3EeaOH59TuV453g" x="1205" y="591"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2gU9ETx3EeaOH59TuV453g" x="30" y="331"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_4GozkDx3EeaOH59TuV453g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_4GpaoDx3EeaOH59TuV453g" type="Stereotype_NameLabel"/>
@@ -1806,7 +1818,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4Gpaqjx3EeaOH59TuV453g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_4GoMgDx3EeaOH59TuV453g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4GozkTx3EeaOH59TuV453g" x="1412" y="592"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4GozkTx3EeaOH59TuV453g" x="242" y="331"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_bTNS4D3UEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_bTNS4j3UEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1823,7 +1835,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bTNS7D3UEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_bTMEwD3UEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bTNS4T3UEeaPco63Cq703g" x="837" y="768"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bTNS4T3UEeaPco63Cq703g" x="485" y="30"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_dhJxID3UEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_dhJxIj3UEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1852,7 +1864,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dhJxLD3UEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_dhJKED3UEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dhJxIT3UEeaPco63Cq703g" x="166" y="647"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dhJxIT3UEeaPco63Cq703g" x="1038" y="30"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_jIP8gD3UEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_jIQjkD3UEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1869,7 +1881,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jIQjmj3UEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_jIPVcD3UEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jIP8gT3UEeaPco63Cq703g" x="618" y="600"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jIP8gT3UEeaPco63Cq703g" x="878" y="30"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_mNBVED3UEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_mNBVEj3UEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1898,6 +1910,22 @@
           <element xmi:type="uml:Property" href="DICE.profile.uml#_nhCQwIl6EeaFpJw9Inr05g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_nhVLsYl6EeaFpJw9Inr05g"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_0RqGYP5kEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_0Qj6MP5kEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_0RqGYf5kEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_JyqwwP5lEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_JxynAP5lEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Jyqwwf5lEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_KmASMP5lEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_KlEeEP5lEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_KmASMf5lEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LirV0P5lEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_Lh3dgP5lEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LirV0f5lEeastMYiWd95zQ"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_mNB8IT3UEeaPco63Cq703g"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_mNB8Ij3UEeaPco63Cq703g"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_mNB8Iz3UEeaPco63Cq703g"/>
@@ -1910,7 +1938,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mNB8KT3UEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_mNAuAD3UEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mNBVET3UEeaPco63Cq703g" x="749" y="601"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mNBVET3UEeaPco63Cq703g" x="645" y="30"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Q0C1QD3oEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_Q0DcUD3oEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1931,7 +1959,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q0DcWj3oEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Q0COMD3oEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q0C1QT3oEeaPco63Cq703g" x="693" y="110"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q0C1QT3oEeaPco63Cq703g" x="408" y="949"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_cyLlwD3pEeaPco63Cq703g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_cyLlwj3pEeaPco63Cq703g" type="Stereotype_NameLabel"/>
@@ -1956,7 +1984,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cyLlzD3pEeaPco63Cq703g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_cyK-sD3pEeaPco63Cq703g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cyLlwT3pEeaPco63Cq703g" x="169" y="114"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cyLlwT3pEeaPco63Cq703g" x="51" y="949"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_CK_0UD4AEeahGZm0A1o1gg" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_CK_0Uj4AEeahGZm0A1o1gg" type="Stereotype_NameLabel"/>
@@ -1989,32 +2017,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CLAbZD4AEeahGZm0A1o1gg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_CK01MD4AEeahGZm0A1o1gg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CK_0UT4AEeahGZm0A1o1gg" x="639" y="-93"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xlggYD4NEeahGZm0A1o1gg" type="Stereotype_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_xlggYj4NEeahGZm0A1o1gg" type="Stereotype_NameLabel"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xlggYz4NEeahGZm0A1o1gg" type="Stereotype_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_izXsUD4OEeahGZm0A1o1gg" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_izQXkD4OEeahGZm0A1o1gg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_izXsUT4OEeahGZm0A1o1gg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_3lo3wD7GEeaP6dbGsA0KOA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_3lGFMD7GEeaP6dbGsA0KOA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_3lo3wT7GEeaP6dbGsA0KOA"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xlggZD4NEeahGZm0A1o1gg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xlggZT4NEeahGZm0A1o1gg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xlggZj4NEeahGZm0A1o1gg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xlggZz4NEeahGZm0A1o1gg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_xlggaD4NEeahGZm0A1o1gg" type="Stereotype_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_xlggaT4NEeahGZm0A1o1gg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_xlggaj4NEeahGZm0A1o1gg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_xlggaz4NEeahGZm0A1o1gg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xlggbD4NEeahGZm0A1o1gg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_xlf5UD4NEeahGZm0A1o1gg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xlggYT4NEeahGZm0A1o1gg" x="870" y="-77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CK_0UT4AEeahGZm0A1o1gg" x="229" y="1122"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JVYK0z4VEeahGZm0A1o1gg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_JVYK1D4VEeahGZm0A1o1gg"/>
@@ -2054,7 +2057,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_QqUjQIlwEeaFpJw9Inr05g" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_TOBPEIlwEeaFpJw9Inr05g" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#CommunicationPath"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QqVKUIlwEeaFpJw9Inr05g" x="127" y="6"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QqVKUIlwEeaFpJw9Inr05g" x="69" y="1122"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Qqrvo4lwEeaFpJw9Inr05g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QqrvpIlwEeaFpJw9Inr05g"/>
@@ -2078,7 +2081,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_Zg1Q8olwEeaFpJw9Inr05g" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_bQCkwIlwEeaFpJw9Inr05g" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Artifact"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg14AIlwEeaFpJw9Inr05g" x="1131" y="-1"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg14AIlwEeaFpJw9Inr05g" x="1762" y="331"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ZhD6cIlwEeaFpJw9Inr05g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_ZhD6cYlwEeaFpJw9Inr05g"/>
@@ -2102,7 +2105,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_sxbF8IlyEeaFpJw9Inr05g" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_t8hAEIlyEeaFpJw9Inr05g" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Device"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sxbF8YlyEeaFpJw9Inr05g" x="1442" y="207"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sxbF8YlyEeaFpJw9Inr05g" x="248" y="949"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_sx18sIlyEeaFpJw9Inr05g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_sx18sYlyEeaFpJw9Inr05g"/>
@@ -2115,6 +2118,14 @@
     <children xmi:type="notation:Shape" xmi:id="_x5X3MIlyEeaFpJw9Inr05g" type="Stereotype_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_x5X3MolyEeaFpJw9Inr05g" type="Stereotype_NameLabel"/>
       <children xmi:type="notation:BasicCompartment" xmi:id="_x5X3M4lyEeaFpJw9Inr05g" type="Stereotype_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_A1CR8P5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_A0m0IP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_A1CR8f5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BtCQ8P5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_BsihsP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BtCQ8f5mEeastMYiWd95zQ"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_x5X3NIlyEeaFpJw9Inr05g"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_x5X3NYlyEeaFpJw9Inr05g"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_x5X3NolyEeaFpJw9Inr05g"/>
@@ -2127,7 +2138,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x5YeQ4lyEeaFpJw9Inr05g"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_x5WpEIlyEeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x5X3MYlyEeaFpJw9Inr05g" x="1285" y="99"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x5X3MYlyEeaFpJw9Inr05g" x="2052" y="30"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_AteksIlzEeaFpJw9Inr05g" type="Class_MetaclassShape" fillColor="10011046">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AtfLwYlzEeaFpJw9Inr05g" source="Stereotype_Annotation">
@@ -2143,7 +2154,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_AteksolzEeaFpJw9Inr05g" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_ECpJsIlzEeaFpJw9Inr05g" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Node"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtfLwIlzEeaFpJw9Inr05g" x="252" y="267"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtfLwIlzEeaFpJw9Inr05g" x="629" y="949"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_AtucU4lzEeaFpJw9Inr05g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_AtucVIlzEeaFpJw9Inr05g"/>
@@ -2152,86 +2163,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtucVYlzEeaFpJw9Inr05g" x="441" y="401"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_eWXVIIlzEeaFpJw9Inr05g" type="Stereotype_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_eWXVIolzEeaFpJw9Inr05g" type="Stereotype_NameLabel"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_eWXVI4lzEeaFpJw9Inr05g" type="Stereotype_AttributeCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_f1e-gIlzEeaFpJw9Inr05g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_f1MDkIlzEeaFpJw9Inr05g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_f1e-gYlzEeaFpJw9Inr05g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_mBP9MIlzEeaFpJw9Inr05g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_mBAFkIlzEeaFpJw9Inr05g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_mBP9MYlzEeaFpJw9Inr05g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_sfFjUIlzEeaFpJw9Inr05g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_sewMIIlzEeaFpJw9Inr05g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_sfFjUYlzEeaFpJw9Inr05g"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_yK2zUIlzEeaFpJw9Inr05g" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_yKltkIlzEeaFpJw9Inr05g"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_yK2zUYlzEeaFpJw9Inr05g"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_eWXVJIlzEeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_eWXVJYlzEeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_eWXVJolzEeaFpJw9Inr05g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eWXVJ4lzEeaFpJw9Inr05g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_eWX8MIlzEeaFpJw9Inr05g" type="Stereotype_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_eWX8MYlzEeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_eWX8MolzEeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_eWX8M4lzEeaFpJw9Inr05g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eWX8NIlzEeaFpJw9Inr05g"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_eWWHAIlzEeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eWXVIYlzEeaFpJw9Inr05g" x="-46" y="490"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Z76mQIl3EeaFpJw9Inr05g" type="Stereotype_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Z76mQol3EeaFpJw9Inr05g" type="Stereotype_NameLabel"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Z76mQ4l3EeaFpJw9Inr05g" type="Stereotype_AttributeCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Z76mRIl3EeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Z76mRYl3EeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Z76mRol3EeaFpJw9Inr05g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z76mR4l3EeaFpJw9Inr05g"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_Z76mSIl3EeaFpJw9Inr05g" type="Stereotype_OperationCompartment">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_Z76mSYl3EeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_Z76mSol3EeaFpJw9Inr05g"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_Z76mS4l3EeaFpJw9Inr05g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z76mTIl3EeaFpJw9Inr05g"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Z75YIIl3EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z76mQYl3EeaFpJw9Inr05g" x="-19" y="674"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_egQ7MIl3EeaFpJw9Inr05g" type="Constraint_PackagedElementShape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_egRiQIl3EeaFpJw9Inr05g" type="Constraint_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_egRiQYl3EeaFpJw9Inr05g" type="Constraint_BodyLabel"/>
-      <element xmi:type="uml:Constraint" href="DICE.profile.uml#_egPtEIl3EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_egQ7MYl3EeaFpJw9Inr05g" x="-473" y="668"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_G2mQUIl5EeaFpJw9Inr05g" type="Constraint_PackagedElementShape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_G2mQUol5EeaFpJw9Inr05g" type="Constraint_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_G2mQU4l5EeaFpJw9Inr05g" type="Constraint_BodyLabel"/>
-      <element xmi:type="uml:Constraint" href="DICE.profile.uml#_G2lCMIl5EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G2mQUYl5EeaFpJw9Inr05g" x="902" y="517"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_DPPdMIl7EeaFpJw9Inr05g" type="Constraint_PackagedElementShape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_DPPdMol7EeaFpJw9Inr05g" type="Constraint_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_DPPdM4l7EeaFpJw9Inr05g" type="Constraint_BodyLabel"/>
-      <element xmi:type="uml:Constraint" href="DICE.profile.uml#_DPOPEIl7EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DPPdMYl7EeaFpJw9Inr05g" x="93" y="797"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_so5wMIl_EeaFpJw9Inr05g" type="Constraint_PackagedElementShape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_so5wMol_EeaFpJw9Inr05g" type="Constraint_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_so6XQIl_EeaFpJw9Inr05g" type="Constraint_BodyLabel"/>
-      <element xmi:type="uml:Constraint" href="DICE.profile.uml#_so4iEIl_EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_so5wMYl_EeaFpJw9Inr05g" x="-485" y="504"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3jvGEIl_EeaFpJw9Inr05g" type="Constraint_PackagedElementShape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_3jvGEol_EeaFpJw9Inr05g" type="Constraint_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_3jvGE4l_EeaFpJw9Inr05g" type="Constraint_BodyLabel"/>
-      <element xmi:type="uml:Constraint" href="DICE.profile.uml#_3jt38Il_EeaFpJw9Inr05g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3jvGEYl_EeaFpJw9Inr05g" x="1040" y="778"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GmLKgImAEeaFpJw9Inr05g" type="Class_MetaclassShape" fillColor="10011046">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GmLxkomAEeaFpJw9Inr05g" source="Stereotype_Annotation">
@@ -2247,7 +2178,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_GmLxkImAEeaFpJw9Inr05g" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_MXxVsImAEeaFpJw9Inr05g" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Deployment"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GmLxkYmAEeaFpJw9Inr05g" x="1282" y="-3"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GmLxkYmAEeaFpJw9Inr05g" x="2098" y="331"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GmZ0AImAEeaFpJw9Inr05g" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_GmZ0AYmAEeaFpJw9Inr05g"/>
@@ -2268,6 +2199,14 @@
           <element xmi:type="uml:Property" href="DICE.profile.uml#_IHtKYJwmEeazaZ28rFZtgA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_IIcKMZwmEeazaZ28rFZtgA"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_80P9EP5lEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_8zyqEP5lEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_80P9Ef5lEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_9s2ZAP5lEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_9sbiQP5lEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_9s2ZAf5lEeastMYiWd95zQ"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_3QYA4ZwlEeazaZ28rFZtgA"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_3QYA4pwlEeazaZ28rFZtgA"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_3QYA45wlEeazaZ28rFZtgA"/>
@@ -2280,27 +2219,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3QYA6ZwlEeazaZ28rFZtgA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_3QGUEJwlEeazaZ28rFZtgA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3QWLsZwlEeazaZ28rFZtgA" x="1059" y="103"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_TMFBUJwnEeazaZ28rFZtgA" type="Class_MetaclassShape">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TMIEoJwnEeazaZ28rFZtgA" source="Stereotype_Annotation">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TMIrsJwnEeazaZ28rFZtgA" key="StereotypeWithQualifiedNameList" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TMIrsZwnEeazaZ28rFZtgA" key="StereotypeList" value="StandardProfile::Metaclass"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TMIrspwnEeazaZ28rFZtgA" key="Stereotype_Presentation_Kind" value="HorizontalStereo"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TMIrs5wnEeazaZ28rFZtgA" key="PropStereoDisplay" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TMIrtJwnEeazaZ28rFZtgA" key="StereotypePropertyLocation" value="Compartment"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_TMFoYJwnEeazaZ28rFZtgA" type="Class_MetaclassNameLabel"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TMGPcJwnEeazaZ28rFZtgA" x="1961" y="107"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_TMvIoJwnEeazaZ28rFZtgA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_TMvIoZwnEeazaZ28rFZtgA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TMvIo5wnEeazaZ28rFZtgA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TMvIopwnEeazaZ28rFZtgA" x="2161" y="107"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3QWLsZwlEeazaZ28rFZtgA" x="1754" y="83"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_WujCgJwnEeazaZ28rFZtgA" type="Class_MetaclassShape" fillColor="10011046">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Z8EucJwnEeazaZ28rFZtgA" source="QualifiedName">
@@ -2309,7 +2228,7 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_WujpkJwnEeazaZ28rFZtgA" type="Class_MetaclassNameLabel"/>
       <styles xmi:type="notation:IntValueStyle" xmi:id="_ZAKf0JwnEeazaZ28rFZtgA" name="shapeDirection" intValue="4"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WujCgZwnEeazaZ28rFZtgA" x="1447" y="-4"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WujCgZwnEeazaZ28rFZtgA" x="2305" y="331"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Wu2kgJwnEeazaZ28rFZtgA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Wu2kgZwnEeazaZ28rFZtgA"/>
@@ -2334,7 +2253,131 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d7ACKZwnEeazaZ28rFZtgA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_d69l4JwnEeazaZ28rFZtgA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6_bEZwnEeazaZ28rFZtgA" x="1472" y="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6_bEZwnEeazaZ28rFZtgA" x="2305" y="30"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Q1ZzsP5lEeastMYiWd95zQ" type="Stereotype_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q1aawP5lEeastMYiWd95zQ" type="Stereotype_NameLabel"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q1bB0P5lEeastMYiWd95zQ" type="Stereotype_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_Fws6sP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_FwSD8P5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Fws6sf5mEeastMYiWd95zQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q1bB0f5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q1bB0v5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q1bB0_5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q1bB1P5lEeastMYiWd95zQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Q1bB1f5lEeastMYiWd95zQ" type="Stereotype_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Q1bB1v5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Q1bB1_5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Q1bB2P5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q1bB2f5lEeastMYiWd95zQ"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_Q1XXcP5lEeastMYiWd95zQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q1Zzsf5lEeastMYiWd95zQ" x="445" y="331"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_SIRw0P5lEeastMYiWd95zQ" type="Stereotype_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SIRw0v5lEeastMYiWd95zQ" type="Stereotype_NameLabel"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SIRw0_5lEeastMYiWd95zQ" type="Stereotype_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SISX4P5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SISX4f5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SISX4v5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SISX4_5lEeastMYiWd95zQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_SISX5P5lEeastMYiWd95zQ" type="Stereotype_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_SISX5f5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_SISX5v5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_SISX5_5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SISX6P5lEeastMYiWd95zQ"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_SIP7oP5lEeastMYiWd95zQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SIRw0f5lEeastMYiWd95zQ" x="958" y="331"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VVM_0P5lEeastMYiWd95zQ" type="Stereotype_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VVM_0v5lEeastMYiWd95zQ" type="Stereotype_NameLabel"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VVNm4P5lEeastMYiWd95zQ" type="Stereotype_AttributeCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VVNm4f5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VVNm4v5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VVNm4_5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VVNm5P5lEeastMYiWd95zQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VVNm5f5lEeastMYiWd95zQ" type="Stereotype_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VVNm5v5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VVNm5_5lEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VVNm6P5lEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VVNm6f5lEeastMYiWd95zQ"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_VVLKoP5lEeastMYiWd95zQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VVM_0f5lEeastMYiWd95zQ" x="325" y="30"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iqqlEP5lEeastMYiWd95zQ" type="Class_MetaclassShape">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iqtBUP5lEeastMYiWd95zQ" source="Stereotype_Annotation">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iqtBUf5lEeastMYiWd95zQ" key="StereotypeWithQualifiedNameList" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iqtoYP5lEeastMYiWd95zQ" key="StereotypeList" value="StandardProfile::Metaclass"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iqtoYf5lEeastMYiWd95zQ" key="Stereotype_Presentation_Kind" value="HorizontalStereo"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iqtoYv5lEeastMYiWd95zQ" key="PropStereoDisplay" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iqtoY_5lEeastMYiWd95zQ" key="StereotypePropertyLocation" value="Compartment"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_iqrMIP5lEeastMYiWd95zQ" type="Class_MetaclassNameLabel"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iqrMIf5lEeastMYiWd95zQ" x="685" y="331"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_irV6gP5lEeastMYiWd95zQ" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_irV6gf5lEeastMYiWd95zQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_irWhkP5lEeastMYiWd95zQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_irV6gv5lEeastMYiWd95zQ" x="1843" y="96"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HWelsP5mEeastMYiWd95zQ" type="Stereotype_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HWfMwP5mEeastMYiWd95zQ" type="Stereotype_NameLabel"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HWfMwf5mEeastMYiWd95zQ" type="Stereotype_AttributeCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_JbrXoP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_JbP50P5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_JbrXof5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_Rm3QYP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_RmakcP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_Rm3QYf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TaxeAP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_TaRHsP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TaxeAf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_VF0qkP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_VFX-oP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_VF0qkf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_XYc0gP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_XYBWsP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_XYc0gf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_aVNgkP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_aUxbsP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_aVNgkf5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_bY-DoP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_bYdGQP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_bY-Dof5mEeastMYiWd95zQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_dMkvQP5mEeastMYiWd95zQ" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_dMGOIP5mEeastMYiWd95zQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_dMkvQf5mEeastMYiWd95zQ"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HWfMwv5mEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HWfMw_5mEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HWfMxP5mEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HWfMxf5mEeastMYiWd95zQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HWfMxv5mEeastMYiWd95zQ" type="Stereotype_OperationCompartment">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_HWfMx_5mEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_HWfMyP5mEeastMYiWd95zQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_HWfMyf5mEeastMYiWd95zQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HWfMyv5mEeastMYiWd95zQ"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="DICE.profile.uml#_HWcwgP5mEeastMYiWd95zQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HWelsf5mEeastMYiWd95zQ" x="1227" y="30"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_MQZzoTx3EeaOH59TuV453g" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_MQZzojx3EeaOH59TuV453g"/>
@@ -2342,7 +2385,7 @@
       <owner xmi:type="uml:Profile" href="DICE.profile.uml#_MPXosOePEeWj7ZPL8JeBTQ"/>
     </styles>
     <element xmi:type="uml:Profile" href="DICE.profile.uml#_aYmS0Dx2EeaOH59TuV453g"/>
-    <edges xmi:type="notation:Connector" xmi:id="_64xkADx3EeaOH59TuV453g" type="Generalization_Edge" source="_2gU9EDx3EeaOH59TuV453g" target="_Uz4QkDx3EeaOH59TuV453g" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="_64xkADx3EeaOH59TuV453g" type="Generalization_Edge" source="_2gU9EDx3EeaOH59TuV453g" target="_Uz4QkDx3EeaOH59TuV453g">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rsX3sD3qEeaPco63Cq703g" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rsX3sT3qEeaPco63Cq703g" key="routing" value="true"/>
       </eAnnotations>
@@ -2352,11 +2395,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_64xkATx3EeaOH59TuV453g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_64U4EDx3EeaOH59TuV453g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_64xkAjx3EeaOH59TuV453g" points="[884, 454, -643984, -643984]$[884, 468, -643984, -643984]$[942, 468, -643984, -643984]$[942, 436, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_648jIDx3EeaOH59TuV453g" id="(0.6333333333333333,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_648jITx3EeaOH59TuV453g" id="(0.6536312849162011,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_64xkAjx3EeaOH59TuV453g" points="[106, 431, -643984, -643984]$[197, 651, -643984, -643984]$[267, 712, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_648jIDx3EeaOH59TuV453g" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_648jITx3EeaOH59TuV453g" id="(0.2446043165467626,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7k_JwDx3EeaOH59TuV453g" type="Generalization_Edge" source="_4GozkDx3EeaOH59TuV453g" target="_Uz4QkDx3EeaOH59TuV453g" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="_7k_JwDx3EeaOH59TuV453g" type="Generalization_Edge" source="_4GozkDx3EeaOH59TuV453g" target="_Uz4QkDx3EeaOH59TuV453g">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rsYewD3qEeaPco63Cq703g" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rsYewT3qEeaPco63Cq703g" key="routing" value="true"/>
       </eAnnotations>
@@ -2366,11 +2409,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7k_JwTx3EeaOH59TuV453g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_7k8GcDx3EeaOH59TuV453g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7k_Jwjx3EeaOH59TuV453g" points="[1037, 451, -643984, -643984]$[1037, 468, -643984, -643984]$[942, 468, -643984, -643984]$[942, 436, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lITsDx3EeaOH59TuV453g" id="(0.20725388601036268,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lITsTx3EeaOH59TuV453g" id="(0.6536312849162011,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7k_Jwjx3EeaOH59TuV453g" points="[302, 652, -643984, -643984]$[302, 712, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lITsDx3EeaOH59TuV453g" id="(0.4195804195804196,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7lITsTx3EeaOH59TuV453g" id="(0.49640287769784175,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_v01j4D3UEeaPco63Cq703g" type="Generalization_Edge" source="_bTNS4D3UEeaPco63Cq703g" target="_VW7TQDx3EeaOH59TuV453g">
+    <edges xmi:type="notation:Connector" xmi:id="_v01j4D3UEeaPco63Cq703g" type="Generalization_Edge" source="_bTNS4D3UEeaPco63Cq703g" target="_Q1ZzsP5lEeastMYiWd95zQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjhL9D3-EeahGZm0A1o1gg" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjhL9T3-EeahGZm0A1o1gg" key="routing" value="true"/>
       </eAnnotations>
@@ -2380,11 +2423,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_v01j4T3UEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_v0wrYD3UEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v01j4j3UEeaPco63Cq703g" points="[871, 773, -643984, -643984]$[965, 430, -643984, -643984]$[524, 430, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v1BKED3UEeaPco63Cq703g" id="(0.756578947368421,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v1BKET3UEeaPco63Cq703g" id="(1.0,0.33112582781456956)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v01j4j3UEeaPco63Cq703g" points="[535, 130, -643984, -643984]$[535, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v1BKED3UEeaPco63Cq703g" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v1BKET3UEeaPco63Cq703g" id="(0.5,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wRsfAD3UEeaPco63Cq703g" type="Generalization_Edge" source="_dhJxID3UEeaPco63Cq703g" target="_VW7TQDx3EeaOH59TuV453g">
+    <edges xmi:type="notation:Connector" xmi:id="_wRsfAD3UEeaPco63Cq703g" type="Generalization_Edge" source="_dhJxID3UEeaPco63Cq703g" target="_SIRw0P5lEeastMYiWd95zQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjhL8D3-EeahGZm0A1o1gg" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjhL8T3-EeahGZm0A1o1gg" key="routing" value="true"/>
       </eAnnotations>
@@ -2394,11 +2437,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_wRsfAT3UEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_wRnmgD3UEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wRsfAj3UEeaPco63Cq703g"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wR3eID3UEeaPco63Cq703g" id="(0.46715328467153283,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wR3eIT3UEeaPco63Cq703g" id="(0.34065934065934067,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wRsfAj3UEeaPco63Cq703g" points="[1102, 159, -643984, -643984]$[1010, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wR3eID3UEeaPco63Cq703g" id="(0.49612403100775193,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wR3eIT3UEeaPco63Cq703g" id="(0.49523809523809526,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_wyv9oD3UEeaPco63Cq703g" type="Generalization_Edge" source="_jIP8gD3UEeaPco63Cq703g" target="_VW7TQDx3EeaOH59TuV453g">
+    <edges xmi:type="notation:Connector" xmi:id="_wyv9oD3UEeaPco63Cq703g" type="Generalization_Edge" source="_jIP8gD3UEeaPco63Cq703g" target="_SIRw0P5lEeastMYiWd95zQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjhzAD3-EeahGZm0A1o1gg" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjhzAT3-EeahGZm0A1o1gg" key="routing" value="true"/>
       </eAnnotations>
@@ -2408,11 +2451,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_wyv9oT3UEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_wyqeED3UEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wyv9oj3UEeaPco63Cq703g"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wy6VsD3UEeaPco63Cq703g" id="(0.48,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wy6VsT3UEeaPco63Cq703g" id="(0.6959706959706959,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wyv9oj3UEeaPco63Cq703g" points="[944, 130, -643984, -643984]$[984, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wy6VsD3UEeaPco63Cq703g" id="(0.66,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wy6VsT3UEeaPco63Cq703g" id="(0.24761904761904763,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xZXRsD3UEeaPco63Cq703g" type="Generalization_Edge" source="_mNBVED3UEeaPco63Cq703g" target="_VW7TQDx3EeaOH59TuV453g">
+    <edges xmi:type="notation:Connector" xmi:id="_xZXRsD3UEeaPco63Cq703g" type="Generalization_Edge" source="_mNBVED3UEeaPco63Cq703g" target="_Q1ZzsP5lEeastMYiWd95zQ">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JjhzAj3-EeahGZm0A1o1gg" source="PapyrusCSSForceValue">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_JjhzAz3-EeahGZm0A1o1gg" key="routing" value="true"/>
       </eAnnotations>
@@ -2422,53 +2465,65 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_xZXRsT3UEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_xZSZMD3UEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xZXRsj3UEeaPco63Cq703g" points="[754, 601, -643984, -643984]$[754, 453, -643984, -643984]$[524, 453, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xZiQ0D3UEeaPco63Cq703g" id="(0.05,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xZiQ0T3UEeaPco63Cq703g" id="(1.0,0.48344370860927155)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xZXRsj3UEeaPco63Cq703g" points="[690, 271, -643984, -643984]$[580, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xZiQ0D3UEeaPco63Cq703g" id="(0.26011560693641617,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xZiQ0T3UEeaPco63Cq703g" id="(0.75,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UUOXcD3oEeaPco63Cq703g" type="Generalization_Edge" source="_VW7TQDx3EeaOH59TuV453g" target="_Q0C1QD3oEeaPco63Cq703g" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="_UUOXcD3oEeaPco63Cq703g" type="Generalization_Edge" source="_VW7TQDx3EeaOH59TuV453g" target="_Q0C1QD3oEeaPco63Cq703g">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dwtecP5jEeastMYiWd95zQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dwtecf5jEeastMYiWd95zQ" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_UUOXcz3oEeaPco63Cq703g" type="Generalization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_yN7LED3oEeaPco63Cq703g" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_UUOXdD3oEeaPco63Cq703g" y="40"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_UUOXcT3oEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_UUD_YD3oEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UUOXcj3oEeaPco63Cq703g" points="[571, 271, -643984, -643984]$[571, 271, -643984, -643984]$[753, 271, -643984, -643984]$[753, 221, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUbLwD3oEeaPco63Cq703g" id="(1.0,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUbLwT3oEeaPco63Cq703g" id="(0.8734939759036144,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UUOXcj3oEeaPco63Cq703g" points="[626, 889, -643984, -643984]$[515, 949, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUbLwD3oEeaPco63Cq703g" id="(0.24880382775119617,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UUbLwT3oEeaPco63Cq703g" id="(0.6645962732919255,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Uws4ED3oEeaPco63Cq703g" type="Generalization_Edge" source="_Uz4QkDx3EeaOH59TuV453g" target="_Q0C1QD3oEeaPco63Cq703g" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="_Uws4ED3oEeaPco63Cq703g" type="Generalization_Edge" source="_Uz4QkDx3EeaOH59TuV453g" target="_Q0C1QD3oEeaPco63Cq703g">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dwk7kP5jEeastMYiWd95zQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dwk7kf5jEeastMYiWd95zQ" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_Uws4Ez3oEeaPco63Cq703g" type="Generalization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_vBQI0D3qEeaPco63Cq703g" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Uws4FD3oEeaPco63Cq703g" y="40"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Uws4ET3oEeaPco63Cq703g"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_UwmxcD3oEeaPco63Cq703g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uws4Ej3oEeaPco63Cq703g" points="[865, 270, -643984, -643984]$[865, 271, -643984, -643984]$[776, 271, -643984, -643984]$[776, 239, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uw66gD3oEeaPco63Cq703g" id="(1.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uw66gT3oEeaPco63Cq703g" id="(0.49818181818181817,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uws4Ej3oEeaPco63Cq703g" points="[335, 889, -643984, -643984]$[461, 949, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uw66gD3oEeaPco63Cq703g" id="(0.7338129496402878,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uw66gT3oEeaPco63Cq703g" id="(0.32919254658385094,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="__Yuc0D4GEeahGZm0A1o1gg" type="Generalization_Edge" source="_cyLlwD3pEeaPco63Cq703g" target="_CK_0UD4AEeahGZm0A1o1gg" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="__Yuc0D4GEeahGZm0A1o1gg" type="Generalization_Edge" source="_cyLlwD3pEeaPco63Cq703g" target="_CK_0UD4AEeahGZm0A1o1gg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dwzlEP5jEeastMYiWd95zQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dwzlEf5jEeastMYiWd95zQ" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="__Yuc0z4GEeahGZm0A1o1gg" type="Generalization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_JYc1UD4HEeahGZm0A1o1gg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="__Yuc1D4GEeahGZm0A1o1gg" y="39"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__Yuc0T4GEeahGZm0A1o1gg"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#__YmhAD4GEeahGZm0A1o1gg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Yuc0j4GEeahGZm0A1o1gg" points="[310, 114, -643984, -643984]$[310, 77, -643984, -643984]$[719, 77, -643984, -643984]$[719, 50, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Y9tYD4GEeahGZm0A1o1gg" id="(0.9155844155844156,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Y9tYT4GEeahGZm0A1o1gg" id="(0.3812154696132597,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__Yuc0j4GEeahGZm0A1o1gg" points="[153, 1062, -643984, -643984]$[284, 1122, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Y9tYD4GEeahGZm0A1o1gg" id="(0.7445255474452555,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__Y9tYT4GEeahGZm0A1o1gg" id="(0.3333333333333333,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Av6SMD4HEeahGZm0A1o1gg" type="Generalization_Edge" source="_Q0C1QD3oEeaPco63Cq703g" target="_CK_0UD4AEeahGZm0A1o1gg" routing="Tree">
+    <edges xmi:type="notation:Connector" xmi:id="_Av6SMD4HEeahGZm0A1o1gg" type="Generalization_Edge" source="_Q0C1QD3oEeaPco63Cq703g" target="_CK_0UD4AEeahGZm0A1o1gg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dw2BUP5jEeastMYiWd95zQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_dw2BUf5jEeastMYiWd95zQ" key="routing" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_Av6SMz4HEeahGZm0A1o1gg" type="Generalization_StereotypeLabel">
         <styles xmi:type="notation:BooleanValueStyle" xmi:id="_B-itYIYlEeaCoLv4GRL90Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xmi:type="notation:Location" xmi:id="_Av6SND4HEeahGZm0A1o1gg" y="40"/>
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_Av6SMT4HEeahGZm0A1o1gg"/>
       <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Avy9cD4HEeahGZm0A1o1gg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Av6SMj4HEeahGZm0A1o1gg" points="[758, 110, -643984, -643984]$[758, 99, -643984, -643984]$[763, 99, -643984, -643984]$[763, 67, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AwI7sD4HEeahGZm0A1o1gg" id="(0.23636363636363636,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AwI7sT4HEeahGZm0A1o1gg" id="(0.6850828729281768,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Av6SMj4HEeahGZm0A1o1gg" points="[488, 1049, -643984, -643984]$[339, 1122, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AwI7sD4HEeahGZm0A1o1gg" id="(0.4968944099378882,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AwI7sT4HEeahGZm0A1o1gg" id="(0.6666666666666666,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QqsWsYlwEeaFpJw9Inr05g" type="StereotypeCommentLink" source="_QqT8MIlwEeaFpJw9Inr05g" target="_Qqrvo4lwEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_QqsWsolwEeaFpJw9Inr05g"/>
@@ -2483,9 +2538,9 @@
     <edges xmi:type="notation:Connector" xmi:id="_XMAHkIlwEeaFpJw9Inr05g" type="Extension_Edge" source="_cyLlwD3pEeaPco63Cq703g" target="_QqT8MIlwEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_XMAHkYlwEeaFpJw9Inr05g"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_XLnGAIlwEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XMAHkolwEeaFpJw9Inr05g" points="[198, 114, -643984, -643984]$[181, 58, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XMlWYIlwEeaFpJw9Inr05g" id="(0.16022099447513813,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XMlWYYlwEeaFpJw9Inr05g" id="(0.4778761061946903,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XMAHkolwEeaFpJw9Inr05g" points="[119, 1062, -643984, -643984]$[119, 1122, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XMlWYIlwEeaFpJw9Inr05g" id="(0.49635036496350365,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XMlWYYlwEeaFpJw9Inr05g" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ZhFvoIlwEeaFpJw9Inr05g" type="StereotypeCommentLink" source="_Zg1Q8IlwEeaFpJw9Inr05g" target="_ZhD6cIlwEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_ZhFvoYlwEeaFpJw9Inr05g"/>
@@ -2496,13 +2551,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZhFvoolwEeaFpJw9Inr05g" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZhFvo4lwEeaFpJw9Inr05g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZhFvpIlwEeaFpJw9Inr05g"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cpcnsIlwEeaFpJw9Inr05g" type="Extension_Edge" source="_xlggYD4NEeahGZm0A1o1gg" target="_Zg1Q8IlwEeaFpJw9Inr05g">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cpcnsYlwEeaFpJw9Inr05g"/>
-      <element xmi:type="uml:Extension" href="DICE.profile.uml#_co_UsIlwEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cpcnsolwEeaFpJw9Inr05g" points="[1068, -19, -643984, -643984]$[1131, 4, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cqFg4IlwEeaFpJw9Inr05g" id="(1.0,0.48739495798319327)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cqFg4YlwEeaFpJw9Inr05g" id="(0.0,0.09615384615384616)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_sx2jwIlyEeaFpJw9Inr05g" type="StereotypeCommentLink" source="_sxae4IlyEeaFpJw9Inr05g" target="_sx18sIlyEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_sx2jwYlyEeaFpJw9Inr05g"/>
@@ -2517,9 +2565,9 @@
     <edges xmi:type="notation:Connector" xmi:id="_9RjQYIlyEeaFpJw9Inr05g" type="Extension_Edge" source="_Uz4QkDx3EeaOH59TuV453g" target="_sxae4IlyEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_9RjQYYlyEeaFpJw9Inr05g"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_9RK14IlyEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9RjQYolyEeaFpJw9Inr05g" points="[1145, 309, -643984, -643984]$[1148, 209, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9SN-wIlyEeaFpJw9Inr05g" id="(0.88268156424581,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9SN-wYlyEeaFpJw9Inr05g" id="(0.64,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9RjQYolyEeaFpJw9Inr05g" points="[298, 889, -643984, -643984]$[298, 949, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9SN-wIlyEeaFpJw9Inr05g" id="(0.4676258992805755,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9SN-wYlyEeaFpJw9Inr05g" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_AtucV4lzEeaFpJw9Inr05g" type="StereotypeCommentLink" source="_AteksIlzEeaFpJw9Inr05g" target="_AtucU4lzEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_AtucWIlzEeaFpJw9Inr05g"/>
@@ -2534,85 +2582,9 @@
     <edges xmi:type="notation:Connector" xmi:id="_GOsxkIlzEeaFpJw9Inr05g" type="Extension_Edge" source="_VW7TQDx3EeaOH59TuV453g" target="_AteksIlzEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_GOsxkYlzEeaFpJw9Inr05g"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_GOWMQIlzEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GOsxkolzEeaFpJw9Inr05g" points="[338, 380, -643984, -643984]$[319, 319, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GPWR0IlzEeaFpJw9Inr05g" id="(0.28431372549019607,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GPWR0YlzEeaFpJw9Inr05g" id="(0.67,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3PJMkIlzEeaFpJw9Inr05g" type="Generalization_Edge" source="_eWXVIIlzEeaFpJw9Inr05g" target="_VW7TQDx3EeaOH59TuV453g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_3PJMk4lzEeaFpJw9Inr05g" type="Generalization_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_YkSvMIl7EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_3PJMlIlzEeaFpJw9Inr05g" x="1" y="38"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_3PJMkYlzEeaFpJw9Inr05g"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_3O5U8IlzEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3PJMkolzEeaFpJw9Inr05g" points="[74, 598, -643984, -643984]$[251, 491, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Ppi4IlzEeaFpJw9Inr05g" id="(1.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3Ppi4YlzEeaFpJw9Inr05g" id="(0.0,0.7350993377483444)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_evIdoIl3EeaFpJw9Inr05g" type="Constraint_ContextEdge" source="_egQ7MIl3EeaFpJw9Inr05g" target="_Z76mQIl3EeaFpJw9Inr05g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_evIdo4l3EeaFpJw9Inr05g" type="Constraint_KeywordLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0ESA0Il4EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_evIdpIl3EeaFpJw9Inr05g" y="15"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_evIdoYl3EeaFpJw9Inr05g"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_evIdool3EeaFpJw9Inr05g" points="[-44, 799, -643984, -643984]$[44, 802, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evwIsIl3EeaFpJw9Inr05g" id="(1.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evwIsYl3EeaFpJw9Inr05g" id="(0.0,0.26)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_06RNoIl4EeaFpJw9Inr05g" type="Generalization_Edge" source="_Z76mQIl3EeaFpJw9Inr05g" target="_VW7TQDx3EeaOH59TuV453g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_06R0sIl4EeaFpJw9Inr05g" type="Generalization_StereotypeLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Y1NgEIl7EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_06R0sYl4EeaFpJw9Inr05g" y="39"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_06RNoYl4EeaFpJw9Inr05g"/>
-      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_054MEIl4EeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_06RNool4EeaFpJw9Inr05g" points="[127, 776, -643984, -643984]$[256, 531, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07HiMIl4EeaFpJw9Inr05g" id="(0.8252427184466019,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_07IJQIl4EeaFpJw9Inr05g" id="(0.018315018315018316,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_HJORYIl5EeaFpJw9Inr05g" type="Constraint_ContextEdge" source="_G2mQUIl5EeaFpJw9Inr05g" target="_mNBVED3UEeaPco63Cq703g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_HJORY4l5EeaFpJw9Inr05g" type="Constraint_KeywordLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_aYPD8Il5EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_HJORZIl5EeaFpJw9Inr05g" y="14"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_HJORYYl5EeaFpJw9Inr05g"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HJORYol5EeaFpJw9Inr05g" points="[763, 755, -643984, -643984]$[792, 701, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HJ0uUIl5EeaFpJw9Inr05g" id="(0.0,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HJ0uUYl5EeaFpJw9Inr05g" id="(0.8029556650246306,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_DgoIIIl7EeaFpJw9Inr05g" type="Constraint_ContextEdge" source="_DPPdMIl7EeaFpJw9Inr05g" target="_dhJxID3UEeaPco63Cq703g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_DgoII4l7EeaFpJw9Inr05g" type="Constraint_KeywordLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_XduIsIl7EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_DgoIJIl7EeaFpJw9Inr05g" x="-1" y="13"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_DgoIIYl7EeaFpJw9Inr05g"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_DgoIIol7EeaFpJw9Inr05g" points="[534, 828, -643984, -643984]$[488, 815, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DhV50Il7EeaFpJw9Inr05g" id="(0.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DhV50Yl7EeaFpJw9Inr05g" id="(0.10218978102189781,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_s_9lUIl_EeaFpJw9Inr05g" type="Constraint_ContextEdge" source="_so5wMIl_EeaFpJw9Inr05g" target="_eWXVIIlzEeaFpJw9Inr05g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_s_-MYIl_EeaFpJw9Inr05g" type="Constraint_KeywordLabel">
-        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_0oD_IIl_EeaFpJw9Inr05g" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_s_-MYYl_EeaFpJw9Inr05g" y="15"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_s_9lUYl_EeaFpJw9Inr05g"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_s_9lUol_EeaFpJw9Inr05g" points="[-188, 499, -643984, -643984]$[-46, 504, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tAr-EIl_EeaFpJw9Inr05g" id="(1.0,0.05)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tAr-EYl_EeaFpJw9Inr05g" id="(0.0,0.09271523178807947)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3z_voIl_EeaFpJw9Inr05g" type="Constraint_ContextEdge" source="_3jvGEIl_EeaFpJw9Inr05g" target="_bTNS4D3UEeaPco63Cq703g">
-      <children xmi:type="notation:DecorationNode" xmi:id="_30AWsIl_EeaFpJw9Inr05g" type="Constraint_KeywordLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_30AWsYl_EeaFpJw9Inr05g" y="15"/>
-      </children>
-      <styles xmi:type="notation:FontStyle" xmi:id="_3z_voYl_EeaFpJw9Inr05g"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3z_vool_EeaFpJw9Inr05g" points="[1040, 778, -643984, -643984]$[989, 811, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_30gF8Il_EeaFpJw9Inr05g" id="(0.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_30gF8Yl_EeaFpJw9Inr05g" id="(1.0,0.43)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GOsxkolzEeaFpJw9Inr05g" points="[679, 889, -643984, -643984]$[679, 949, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GPWR0IlzEeaFpJw9Inr05g" id="(0.5023923444976076,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GPWR0YlzEeaFpJw9Inr05g" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_GmabEImAEeaFpJw9Inr05g" type="StereotypeCommentLink" source="_GmLKgImAEeaFpJw9Inr05g" target="_GmZ0AImAEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_GmabEYmAEeaFpJw9Inr05g"/>
@@ -2627,26 +2599,16 @@
     <edges xmi:type="notation:Connector" xmi:id="_Ka1H4ImAEeaFpJw9Inr05g" type="Extension_Edge" source="_x5X3MIlyEeaFpJw9Inr05g" target="_GmLKgImAEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_Ka1H4YmAEeaFpJw9Inr05g"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_Kad7gImAEeaFpJw9Inr05g"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ka1H4omAEeaFpJw9Inr05g" points="[1250, 113, -643984, -643984]$[1298, 47, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KbdaAImAEeaFpJw9Inr05g" id="(0.7589285714285714,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KbdaAYmAEeaFpJw9Inr05g" id="(0.16,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ka1H4omAEeaFpJw9Inr05g" points="[2148, 143, -643984, -643984]$[2148, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KbdaAImAEeaFpJw9Inr05g" id="(0.49740932642487046,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KbdaAYmAEeaFpJw9Inr05g" id="(0.5,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QwzuMJwmEeazaZ28rFZtgA" type="Extension_Edge" source="_3QWLsJwlEeazaZ28rFZtgA" target="_Zg1Q8IlwEeaFpJw9Inr05g">
       <styles xmi:type="notation:FontStyle" xmi:id="_QwzuMZwmEeazaZ28rFZtgA"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_QvNLsJwmEeazaZ28rFZtgA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QwzuMpwmEeazaZ28rFZtgA" points="[1316, 82, -643984, -643984]$[1231, 43, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QyYbgJwmEeazaZ28rFZtgA" id="(0.07453416149068323,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QyZCkJwmEeazaZ28rFZtgA" id="(0.65,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_TMwWwJwnEeazaZ28rFZtgA" type="StereotypeCommentLink" source="_TMFBUJwnEeazaZ28rFZtgA" target="_TMvIoJwnEeazaZ28rFZtgA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_TMwWwZwnEeazaZ28rFZtgA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_TMw90JwnEeazaZ28rFZtgA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TMwWwpwnEeazaZ28rFZtgA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMwWw5wnEeazaZ28rFZtgA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMwWxJwnEeazaZ28rFZtgA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QwzuMpwmEeazaZ28rFZtgA" points="[1917, 175, -643984, -643984]$[1828, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QyYbgJwmEeazaZ28rFZtgA" id="(0.4966442953020134,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QyZCkJwmEeazaZ28rFZtgA" id="(0.66,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Wu3LkJwnEeazaZ28rFZtgA" type="StereotypeCommentLink" source="_WujCgJwnEeazaZ28rFZtgA" target="_Wu2kgJwnEeazaZ28rFZtgA">
       <styles xmi:type="notation:FontStyle" xmi:id="_Wu3LkZwnEeazaZ28rFZtgA"/>
@@ -2661,9 +2623,84 @@
     <edges xmi:type="notation:Connector" xmi:id="_pcfIUJwnEeazaZ28rFZtgA" type="Extension_Edge" source="_d6_bEJwnEeazaZ28rFZtgA" target="_WujCgJwnEeazaZ28rFZtgA">
       <styles xmi:type="notation:FontStyle" xmi:id="_pcfIUZwnEeazaZ28rFZtgA"/>
       <element xmi:type="uml:Extension" href="DICE.profile.uml#_pbqo8JwnEeazaZ28rFZtgA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pcfIUpwnEeazaZ28rFZtgA" points="[1512, 91, -643984, -643984]$[1502, 48, -643984, -643984]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdyI0JwnEeazaZ28rFZtgA" id="(0.31007751937984496,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdyv4JwnEeazaZ28rFZtgA" id="(0.55,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pcfIUpwnEeazaZ28rFZtgA" points="[2355, 130, -643984, -643984]$[2355, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdyI0JwnEeazaZ28rFZtgA" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pdyv4JwnEeazaZ28rFZtgA" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WvQjAP5lEeastMYiWd95zQ" type="Generalization_Edge" source="_VVM_0P5lEeastMYiWd95zQ" target="_Q1ZzsP5lEeastMYiWd95zQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WvRxIP5lEeastMYiWd95zQ" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1uL5UP5lEeastMYiWd95zQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WvRxIf5lEeastMYiWd95zQ" x="2" y="37"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_WvQjAf5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Wul0oP5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WvQjAv5lEeastMYiWd95zQ" points="[375, 130, -643984, -643984]$[440, 270, -643984, -643984]$[490, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WwhuUP5lEeastMYiWd95zQ" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WwhuUf5lEeastMYiWd95zQ" id="(0.25,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_YqYL4P5lEeastMYiWd95zQ" type="Generalization_Edge" source="_Q1ZzsP5lEeastMYiWd95zQ" target="_VW7TQDx3EeaOH59TuV453g">
+      <children xmi:type="notation:DecorationNode" xmi:id="_YqYL4_5lEeastMYiWd95zQ" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1ukT0P5lEeastMYiWd95zQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_YqYL5P5lEeastMYiWd95zQ" x="-1" y="38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_YqYL4f5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_Ypxu8P5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_YqYL4v5lEeastMYiWd95zQ" points="[535, 431, -643984, -643984]$[643, 712, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YrmT4P5lEeastMYiWd95zQ" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YrmT4f5lEeastMYiWd95zQ" id="(0.33014354066985646,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZGfgIP5lEeastMYiWd95zQ" type="Generalization_Edge" source="_SIRw0P5lEeastMYiWd95zQ" target="_VW7TQDx3EeaOH59TuV453g">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZGgHMP5lEeastMYiWd95zQ" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_1uYGkP5lEeastMYiWd95zQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ZGgHMf5lEeastMYiWd95zQ" x="-1" y="38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZGfgIf5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_ZGBmEP5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZGfgIv5lEeastMYiWd95zQ" points="[1010, 431, -643984, -643984]$[829, 651, -643984, -643984]$[713, 712, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHflsP5lEeastMYiWd95zQ" id="(0.49523809523809526,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZHgMwP5lEeastMYiWd95zQ" id="(0.6650717703349283,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_irWhkf5lEeastMYiWd95zQ" type="StereotypeCommentLink" source="_iqqlEP5lEeastMYiWd95zQ" target="_irV6gP5lEeastMYiWd95zQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_irWhkv5lEeastMYiWd95zQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_irXIoP5lEeastMYiWd95zQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_irWhk_5lEeastMYiWd95zQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_irWhlP5lEeastMYiWd95zQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_irWhlf5lEeastMYiWd95zQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jIvoMP5lEeastMYiWd95zQ" type="Extension_Edge" source="_mNBVED3UEeaPco63Cq703g" target="_iqqlEP5lEeastMYiWd95zQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_jIvoMf5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_jH-MIP5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jIvoMv5lEeastMYiWd95zQ" points="[735, 271, -643984, -643984]$[735, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jKJWYP5lEeastMYiWd95zQ" id="(0.5202312138728323,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jKJWYf5lEeastMYiWd95zQ" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jh6WIP5lEeastMYiWd95zQ" type="Extension_Edge" source="_bTNS4D3UEeaPco63Cq703g" target="_iqqlEP5lEeastMYiWd95zQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_jh6WIf5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_jhPAsP5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jh6WIv5lEeastMYiWd95zQ" points="[560, 130, -643984, -643984]$[600, 270, -643984, -643984]$[710, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jjK6YP5lEeastMYiWd95zQ" id="(0.75,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jjK6Yf5lEeastMYiWd95zQ" id="(0.25,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_kNKSkP5lEeastMYiWd95zQ" type="Extension_Edge" source="_jIP8gD3UEeaPco63Cq703g" target="_iqqlEP5lEeastMYiWd95zQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_kNKSkf5lEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Extension" href="DICE.profile.uml#_kMouIP5lEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kNKSkv5lEeastMYiWd95zQ" points="[911, 130, -643984, -643984]$[862, 270, -643984, -643984]$[760, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kOCcUP5lEeastMYiWd95zQ" id="(0.33,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kOCcUf5lEeastMYiWd95zQ" id="(0.75,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_I_S9oP5mEeastMYiWd95zQ" type="Generalization_Edge" source="_HWelsP5mEeastMYiWd95zQ" target="_SIRw0P5lEeastMYiWd95zQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_I_S9o_5mEeastMYiWd95zQ" type="Generalization_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_ft_jIP5mEeastMYiWd95zQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_I_S9pP5mEeastMYiWd95zQ" y="38"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_I_S9of5mEeastMYiWd95zQ"/>
+      <element xmi:type="uml:Generalization" href="DICE.profile.uml#_I-3f0P5mEeastMYiWd95zQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_I_S9ov5mEeastMYiWd95zQ" points="[1332, 239, -643984, -643984]$[1036, 331, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JAKgUP5mEeastMYiWd95zQ" id="(0.5,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JAKgUf5mEeastMYiWd95zQ" id="(0.7428571428571429,0.0)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
@@ -505,7 +505,7 @@
           <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/Ecore.profile.uml#_0"/>
         </profileApplication>
       </packagedElement>
-      <packagedElement xmi:type="uml:Profile" xmi:id="_aYmS0Dx2EeaOH59TuV453g" name="DDSM" metaclassReference="_QqQ44IlwEeaFpJw9Inr05g _Zg0C0IlwEeaFpJw9Inr05g _sxXbkIlyEeaFpJw9Inr05g _AtdWkIlzEeaFpJw9Inr05g _GmKjcImAEeaFpJw9Inr05g _TL-6sJwnEeazaZ28rFZtgA">
+      <packagedElement xmi:type="uml:Profile" xmi:id="_aYmS0Dx2EeaOH59TuV453g" name="DDSM" metaclassReference="_QqQ44IlwEeaFpJw9Inr05g _Zg0C0IlwEeaFpJw9Inr05g _sxXbkIlyEeaFpJw9Inr05g _AtdWkIlzEeaFpJw9Inr05g _GmKjcImAEeaFpJw9Inr05g _TL-6sJwnEeazaZ28rFZtgA _iqoI0P5lEeastMYiWd95zQ">
         <elementImport xmi:type="uml:ElementImport" xmi:id="_QqQ44IlwEeaFpJw9Inr05g" alias="CommunicationPath">
           <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#CommunicationPath"/>
         </elementImport>
@@ -524,10 +524,13 @@
         <elementImport xmi:type="uml:ElementImport" xmi:id="_TL-6sJwnEeazaZ28rFZtgA" alias="Dependency">
           <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
         </elementImport>
+        <elementImport xmi:type="uml:ElementImport" xmi:id="_iqoI0P5lEeastMYiWd95zQ" alias="ExecutionEnvironment">
+          <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+        </elementImport>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_Uz1NQDx3EeaOH59TuV453g" name="DdsmExternalComponent">
           <generalization xmi:type="uml:Generalization" xmi:id="_UwmxcD3oEeaPco63Cq703g" general="_Q0COMD3oEeaPco63Cq703g"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_sMQgYD3kEeaPco63Cq703g" name="location">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_czRFsD37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_czRswD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
@@ -535,24 +538,28 @@
             <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_ToY-oD4IEeahGZm0A1o1gg"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bpBgID37EeahGZm0A1o1gg" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bpCHMD37EeahGZm0A1o1gg" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_D7ek0P5uEeastMYiWd95zQ">
+              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_ToY-oD4IEeahGZm0A1o1gg"/>
+              <instance xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_VrthQD4IEeahGZm0A1o1gg"/>
+            </defaultValue>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_wsFFMD3lEeaPco63Cq703g" name="serviceType">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZlzEID37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZlzrMD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_WDnW0D37EeahGZm0A1o1gg" name="region">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YLozQD37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YLxWID37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_deJ1wD37EeahGZm0A1o1gg" name="login">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fbY-gD37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fbZlkD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_gJR_QD37EeahGZm0A1o1gg" name="password">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iaX4ID37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iaYfMD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
@@ -567,168 +574,225 @@
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vNtiYD3oEeaPco63Cq703g" value="*"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_X3NekD3_EeahGZm0A1o1gg" name="isFrontEnd">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EBoolean"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6p0osP5sEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6p120P5sEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_eIkH4D3_EeahGZm0A1o1gg"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_eLU0sIlxEeaFpJw9Inr05g" name="componentType">
             <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_4Hn0EIlwEeaFpJw9Inr05g"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FOIfgP5uEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FOJtoP5uEeastMYiWd95zQ" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_GOWzUYlzEeaFpJw9Inr05g" name="base_Node" association="_GOWMQIlzEeaFpJw9Inr05g">
             <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Node"/>
           </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_iqnFQP5mEeastMYiWd95zQ" name="protected">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vCgnUP5sEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vCh1cP5sEeastMYiWd95zQ" value="1"/>
+            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_v8BpQP5sEeastMYiWd95zQ"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_mxpMEP5mEeastMYiWd95zQ" name="launch_script">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ymRpAP5sEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ymS3IP5sEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_n26yEP5mEeastMYiWd95zQ" name="language">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0bPmkP5sEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0bRbwP5sEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_2gRSsDx3EeaOH59TuV453g" name="DdsmCluster">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_2gRSsDx3EeaOH59TuV453g" name="DdsmHeterogeneousCluster">
           <generalization xmi:type="uml:Generalization" xmi:id="_64U4EDx3EeaOH59TuV453g" general="_Uz1NQDx3EeaOH59TuV453g"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_iDkKYD3qEeaPco63Cq703g" name="hasVM" type="_4GoMgDx3EeaOH59TuV453g">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_j0Qr8D3qEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_j0RTAD3qEeaPco63Cq703g" value="*"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_4GoMgDx3EeaOH59TuV453g" name="DdsmVm">
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_4GoMgDx3EeaOH59TuV453g" name="DdsmVMsCluster">
           <generalization xmi:type="uml:Generalization" xmi:id="_7k8GcDx3EeaOH59TuV453g" general="_Uz1NQDx3EeaOH59TuV453g"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_GG8FkDx4EeaOH59TuV453g" name="is64os">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EBoolean"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_f3huwDx4EeaOH59TuV453g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_f3jj8Dx4EeaOH59TuV453g" value="1"/>
             <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_i3cB4D3rEeaPco63Cq703g" value="true"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_gzPJEDx4EeaOH59TuV453g" name="imageId">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_v__AEDx4EeaOH59TuV453g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_v__AETx4EeaOH59TuV453g" value="1"/>
             <defaultValue xmi:type="uml:LiteralString" xmi:id="_RlbSED3sEeaPco63Cq703g"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_hKnuUDx4EeaOH59TuV453g" name="maxCores">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_SWJ7IP5tEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SWLJQP5tEeastMYiWd95zQ" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_hxruUDx4EeaOH59TuV453g" name="maxRam">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_j9WIwD3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_j9Wv0D3lEeaPco63Cq703g" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_sRG6kDx4EeaOH59TuV453g" name="maxStorage">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_krRlwD3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_krRlwT3lEeaPco63Cq703g" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_m4CUED3sEeaPco63Cq703g"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_EEU-MD3kEeaPco63Cq703g" name="minCores">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gOuh8D3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gOvJAD3lEeaPco63Cq703g" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_HdzbcD3kEeaPco63Cq703g" name="minRam">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hIBhcD3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hIBhcT3lEeaPco63Cq703g" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_JgKUwD3kEeaPco63Cq703g" name="minStorage">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iEphwD3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iEphwT3lEeaPco63Cq703g" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_rGTEQD3sEeaPco63Cq703g"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_MrJqED3kEeaPco63Cq703g" name="os">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i45pMD3lEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i5VHAD3lEeaPco63Cq703g" value="1"/>
             <defaultValue xmi:type="uml:LiteralString" xmi:id="_bgIAoD3sEeaPco63Cq703g"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_JgRTYD3tEeaPco63Cq703g" name="securityGroup">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_P_9ToD3tEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_P_96sD3tEeaPco63Cq703g" value="1"/>
             <defaultValue xmi:type="uml:LiteralString" xmi:id="_OTHXUD3tEeaPco63Cq703g"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_yLvfID37EeahGZm0A1o1gg" name="privateKey">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1A4gQD37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1A5HUD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_66gmED37EeahGZm0A1o1gg" name="sshKey">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8_RTID37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8_R6MD37EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="__CBOAD37EeahGZm0A1o1gg" name="publicAddress">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ByH-ID38EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ByH-IT38EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_Dl9TQD38EeahGZm0A1o1gg" name="instances">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EIntegerObject"/>
-            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_NMM0wD38EeahGZm0A1o1gg"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1oGNgP5nEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1oIpwP5nEeastMYiWd95zQ" value="1"/>
+            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_0OJYAP5nEeastMYiWd95zQ" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_QmUyQD38EeahGZm0A1o1gg" name="genericSize">
             <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_HOIsID4CEeahGZm0A1o1gg"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pjfLsD4CEeahGZm0A1o1gg"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pjfLsD4CEeahGZm0A1o1gg" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pjfywD4CEeahGZm0A1o1gg" value="1"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_2TVUIP5tEeastMYiWd95zQ">
+              <type xmi:type="uml:Enumeration" href="DICE_Library.uml#_HOIsID4CEeahGZm0A1o1gg"/>
+              <instance xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_MfkJgD4CEeahGZm0A1o1gg"/>
+            </defaultValue>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_bTMEwD3UEeaPco63Cq703g" name="DdsmYarnResourceManager">
-          <ownedRule xmi:type="uml:Constraint" xmi:id="_3jt38Il_EeaFpJw9Inr05g" name="YarnTypeMasterNode" constrainedElement="_eLU0sIlxEeaFpJw9Inr05g">
-            <specification xmi:type="uml:OpaqueExpression" xmi:id="_-pqm8Il_EeaFpJw9Inr05g" name="YarnIsMasterNode">
-              <language>OCL</language>
-              <body>self.componentType = DDSMcomponentType::MasterNode</body>
-            </specification>
-          </ownedRule>
-          <generalization xmi:type="uml:Generalization" xmi:id="_v0wrYD3UEeaPco63Cq703g" general="_VW6FIDx3EeaOH59TuV453g"/>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_bTMEwD3UEeaPco63Cq703g" name="DdsmYarnCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_v0wrYD3UEeaPco63Cq703g" general="_Q1XXcP5lEeastMYiWd95zQ"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_jhPnwf5lEeastMYiWd95zQ" name="base_ExecutionEnvironment" association="_jhPAsP5lEeastMYiWd95zQ">
+            <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+          </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_dhJKED3UEeaPco63Cq703g" name="DdsmZookeeperServer">
-          <ownedRule xmi:type="uml:Constraint" xmi:id="_DPOPEIl7EeaFpJw9Inr05g" name="ZookeeperServerTypePeefNode" constrainedElement="_eLU0sIlxEeaFpJw9Inr05g">
-            <specification xmi:type="uml:OpaqueExpression" xmi:id="_SD6ycIl7EeaFpJw9Inr05g" name="ZookeeperServerIsPeerNode">
-              <language>OCL</language>
-              <body>self.componentType=DDSMcomponentType::PeerNode</body>
-            </specification>
-          </ownedRule>
-          <generalization xmi:type="uml:Generalization" xmi:id="_wRnmgD3UEeaPco63Cq703g" general="_VW6FIDx3EeaOH59TuV453g"/>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_dhJKED3UEeaPco63Cq703g" name="DdsmZookeeperCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_wRnmgD3UEeaPco63Cq703g" general="_SIP7oP5lEeastMYiWd95zQ"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_1KNcMIl6EeaFpJw9Inr05g" name="tickTime">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qYZlcP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qYbaoP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="__k-K4Il6EeaFpJw9Inr05g" value="1500"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_4-C6MIl6EeaFpJw9Inr05g" name="syncLimit">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oFtxIP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oFw0cP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_AQEWUIl7EeaFpJw9Inr05g" value="10"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_8gbb0Il6EeaFpJw9Inr05g" name="initLimit">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o_PaIP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o_RPUP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_BNfn4Il7EeaFpJw9Inr05g" value="5"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_jIPVcD3UEeaPco63Cq703g" name="DdsmKafka">
-          <generalization xmi:type="uml:Generalization" xmi:id="_wyqeED3UEeaPco63Cq703g" general="_VW6FIDx3EeaOH59TuV453g"/>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_jIPVcD3UEeaPco63Cq703g" name="DdsmKafkaCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_wyqeED3UEeaPco63Cq703g" general="_SIP7oP5lEeastMYiWd95zQ"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_kMp8QP5lEeastMYiWd95zQ" name="base_ExecutionEnvironment" association="_kMouIP5lEeastMYiWd95zQ">
+            <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
+          </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_mNAuAD3UEeaPco63Cq703g" name="DdsmNimbus">
-          <ownedRule xmi:type="uml:Constraint" xmi:id="_G2lCMIl5EeaFpJw9Inr05g" name="NimbusTypeMasterNode" constrainedElement="_eLU0sIlxEeaFpJw9Inr05g">
-            <specification xmi:type="uml:OpaqueExpression" xmi:id="_VlzPsIl5EeaFpJw9Inr05g" name="nimbusIsMaster">
-              <language>OCL</language>
-              <body>self.componentType = DDSMcomponentType::MasterNode</body>
-            </specification>
-          </ownedRule>
-          <generalization xmi:type="uml:Generalization" xmi:id="_xZSZMD3UEeaPco63Cq703g" general="_VW6FIDx3EeaOH59TuV453g"/>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_mNAuAD3UEeaPco63Cq703g" name="DdsmStormCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_xZSZMD3UEeaPco63Cq703g" general="_Q1XXcP5lEeastMYiWd95zQ"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_HXxOQIl6EeaFpJw9Inr05g" name="taskTimeout">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rGkTAP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rGlhIP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralString" xmi:id="_UBK-wIl6EeaFpJw9Inr05g" value="60"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_XIq7MIl6EeaFpJw9Inr05g" name="supervisorFrequency">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sidCMP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sieQUP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_sKE4cIl6EeaFpJw9Inr05g" value="60"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_cQlQMIl6EeaFpJw9Inr05g" name="queueSize">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_t3Gg8P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_t3IWIP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_tgbAUIl6EeaFpJw9Inr05g" value="10000"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_fQ2jQIl6EeaFpJw9Inr05g" name="monitorFrequency">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vfwg0P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vfxu8P5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_uUjzAIl6EeaFpJw9Inr05g" value="40"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_itfpQIl6EeaFpJw9Inr05g" name="retryTimes">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_w4ue4P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_w4vtAP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_u8XZ4Il6EeaFpJw9Inr05g" value="5"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_nhCQwIl6EeaFpJw9Inr05g" name="retryInterval">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ySg8UP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ySiKcP5oEeastMYiWd95zQ" value="1"/>
             <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_vp6cYIl6EeaFpJw9Inr05g" value="2000"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_0Qj6MP5kEeastMYiWd95zQ" name="workerStartTimeout">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zxk7UP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zxmJcP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_JxynAP5lEeastMYiWd95zQ" name="cpuCapacity">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2D48MP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2D6xYP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_KlEeEP5lEeastMYiWd95zQ" name="memoryCapacity">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3UQX4P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3URmAP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_Lh3dgP5lEeastMYiWd95zQ" name="heartbeatFrequency">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4ngvgP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4nh9oP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_jIESwP5lEeastMYiWd95zQ" name="base_ExecutionEnvironment" association="_jH-MIP5lEeastMYiWd95zQ">
+            <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#ExecutionEnvironment"/>
           </ownedAttribute>
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_Q0COMD3oEeaPco63Cq703g" name="DdsmComponent" isAbstract="true">
@@ -741,13 +805,13 @@
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_cyK-sD3pEeaPco63Cq703g" name="DdsmPort">
           <generalization xmi:type="uml:Generalization" xmi:id="__YmhAD4GEeahGZm0A1o1gg" general="_CK01MD4AEeahGZm0A1o1gg"/>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_BqG1ID39EeahGZm0A1o1gg" name="isLocal">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EBoolean"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_H4nl0D39EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_H4oM4D39EeahGZm0A1o1gg" value="1"/>
             <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_E7peYD39EeahGZm0A1o1gg"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_IwK44D39EeahGZm0A1o1gg" name="portNumber">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MZ4KgD39EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MZ4xkD39EeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
@@ -757,53 +821,41 @@
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_CK01MD4AEeahGZm0A1o1gg" name="DdsmCloudElement" isAbstract="true">
           <ownedAttribute xmi:type="uml:Property" xmi:id="_Qih6kD4AEeahGZm0A1o1gg" name="description">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mPUoED4JEeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mPVPID4JEeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_nK77wD4JEeahGZm0A1o1gg" name="propertiesList">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p5o9sD4JEeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p5o9sT4JEeahGZm0A1o1gg" value="*"/>
           </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_GANxYD4LEeahGZm0A1o1gg" name="resourcesList" type="_xlf5UD4NEeahGZm0A1o1gg">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_GANxYD4LEeahGZm0A1o1gg" name="resourcesList">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JyoTED4LEeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JyoTET4LEeahGZm0A1o1gg" value="*"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_wbHbwD4LEeahGZm0A1o1gg" name="id">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0D3rID4LEeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0D4SMD4LEeahGZm0A1o1gg" value="1"/>
           </ownedAttribute>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_xlf5UD4NEeahGZm0A1o1gg" name="DdsmResource">
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_izQXkD4OEeahGZm0A1o1gg" name="commandsList">
-            <type xmi:type="uml:DataType" href="DICE_Library.uml#_EgSOsD4WEeahGZm0A1o1gg"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mdnwgD4OEeahGZm0A1o1gg"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mdoXkD4OEeahGZm0A1o1gg" value="*"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_LsM4QD4VEeahGZm0A1o1gg" name="base_Artifact" association="_LsLDED4VEeahGZm0A1o1gg">
-            <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Artifact"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_3lGFMD7GEeaP6dbGsA0KOA" name="id">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_cpAi0IlwEeaFpJw9Inr05g" name="base_Artifact" association="_co_UsIlwEeaFpJw9Inr05g">
-            <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Artifact"/>
-          </ownedAttribute>
-        </packagedElement>
-        <packagedElement xmi:type="uml:Extension" xmi:id="_LsLDED4VEeahGZm0A1o1gg" name="E_DdsmResource_Artifact1" memberEnd="_LsMRMD4VEeahGZm0A1o1gg _LsM4QD4VEeahGZm0A1o1gg">
-          <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_LsMRMD4VEeahGZm0A1o1gg" name="extension_DdsmResource" type="_xlf5UD4NEeahGZm0A1o1gg" aggregation="composite" association="_LsLDED4VEeahGZm0A1o1gg"/>
-        </packagedElement>
         <packagedElement xmi:type="uml:Extension" xmi:id="_XLnGAIlwEeaFpJw9Inr05g" name="E_DdsmPort_CommunicationPath1" memberEnd="_XLoUIIlwEeaFpJw9Inr05g _XLo7MIlwEeaFpJw9Inr05g">
           <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_XLoUIIlwEeaFpJw9Inr05g" name="extension_DdsmPort" type="_cyK-sD3pEeaPco63Cq703g" aggregation="composite" association="_XLnGAIlwEeaFpJw9Inr05g"/>
-        </packagedElement>
-        <packagedElement xmi:type="uml:Extension" xmi:id="_co_UsIlwEeaFpJw9Inr05g" name="E_DdsmResource_Artifact2" memberEnd="_co_7wIlwEeaFpJw9Inr05g _cpAi0IlwEeaFpJw9Inr05g">
-          <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_co_7wIlwEeaFpJw9Inr05g" name="extension_DdsmResource" type="_xlf5UD4NEeahGZm0A1o1gg" aggregation="composite" association="_co_UsIlwEeaFpJw9Inr05g"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_x5WpEIlyEeaFpJw9Inr05g" name="DdsmJobSubmission">
           <ownedAttribute xmi:type="uml:Property" xmi:id="_KaeikYmAEeaFpJw9Inr05g" name="base_Deployment" association="_Kad7gImAEeaFpJw9Inr05g">
             <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Deployment"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_A0m0IP5mEeastMYiWd95zQ" name="numberOfSubmission">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OT7mYP5uEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OT9bkP5uEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_BsihsP5mEeastMYiWd95zQ" name="intervalBetweenSubmission">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PqMOsP5uEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PqNc0P5uEeastMYiWd95zQ" value="1"/>
           </ownedAttribute>
         </packagedElement>
         <packagedElement xmi:type="uml:Extension" xmi:id="_9RK14IlyEeaFpJw9Inr05g" name="E_DdsmExternalComponent_Device1" memberEnd="_9RLc8IlyEeaFpJw9Inr05g _9RLc8YlyEeaFpJw9Inr05g">
@@ -812,52 +864,28 @@
         <packagedElement xmi:type="uml:Extension" xmi:id="_GOWMQIlzEeaFpJw9Inr05g" name="E_DdsmInternalComponent_Node1" memberEnd="_GOWzUIlzEeaFpJw9Inr05g _GOWzUYlzEeaFpJw9Inr05g">
           <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_GOWzUIlzEeaFpJw9Inr05g" name="extension_DdsmInternalComponent" type="_VW6FIDx3EeaOH59TuV453g" aggregation="composite" association="_GOWMQIlzEeaFpJw9Inr05g"/>
         </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_eWWHAIlzEeaFpJw9Inr05g" name="DdsmSupervisor">
-          <ownedRule xmi:type="uml:Constraint" xmi:id="_so4iEIl_EeaFpJw9Inr05g" name="SupervisorTypeSlaveNode" constrainedElement="_eLU0sIlxEeaFpJw9Inr05g">
-            <specification xmi:type="uml:OpaqueExpression" xmi:id="_0L5nkIl_EeaFpJw9Inr05g" name="supervisorIsSlaveNode">
-              <language>OCL</language>
-              <body>self.componentType = DDSMcomponentType::MasterSlavePlatform</body>
-            </specification>
-          </ownedRule>
-          <generalization xmi:type="uml:Generalization" xmi:id="_3O5U8IlzEeaFpJw9Inr05g" general="_VW6FIDx3EeaOH59TuV453g"/>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_f1MDkIlzEeaFpJw9Inr05g" name="workerStartTimeout">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
-            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_oHEaMIlzEeaFpJw9Inr05g" value="120"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_mBAFkIlzEeaFpJw9Inr05g" name="cpuCapacity">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
-            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_rotU8IlzEeaFpJw9Inr05g" value="400"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_sewMIIlzEeaFpJw9Inr05g" name="memoryCapacity">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
-            <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_v_GGYIlzEeaFpJw9Inr05g" value="4096"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_yKltkIlzEeaFpJw9Inr05g" name="heartbeatFrequency">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EInt"/>
-            <defaultValue xmi:type="uml:LiteralString" xmi:id="_0HhUUIlzEeaFpJw9Inr05g" value="5"/>
-          </ownedAttribute>
-        </packagedElement>
-        <packagedElement xmi:type="uml:Stereotype" xmi:id="_Z75YIIl3EeaFpJw9Inr05g" name="DdsmStormCluster">
-          <ownedRule xmi:type="uml:Constraint" xmi:id="_egPtEIl3EeaFpJw9Inr05g" name="StormClusterTypeMasterSlavePlatform" constrainedElement="_eLU0sIlxEeaFpJw9Inr05g">
-            <specification xmi:type="uml:OpaqueExpression" xmi:id="_s2KNQIl4EeaFpJw9Inr05g" name="StormClusterIsMasterSlavePlatform">
-              <language>OCL</language>
-              <body>self.componentType = DDSMcomponentType::MasterSlavePlatform</body>
-            </specification>
-          </ownedRule>
-          <generalization xmi:type="uml:Generalization" xmi:id="_054MEIl4EeaFpJw9Inr05g" general="_VW6FIDx3EeaOH59TuV453g"/>
-        </packagedElement>
         <packagedElement xmi:type="uml:Extension" xmi:id="_Kad7gImAEeaFpJw9Inr05g" name="E_DdsmJobSubmission_Deployment1" memberEnd="_KaeikImAEeaFpJw9Inr05g _KaeikYmAEeaFpJw9Inr05g">
           <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_KaeikImAEeaFpJw9Inr05g" name="extension_DdsmJobSubmission" type="_x5WpEIlyEeaFpJw9Inr05g" aggregation="composite" association="_Kad7gImAEeaFpJw9Inr05g"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_3QGUEJwlEeazaZ28rFZtgA" name="DdsmBigDataJob">
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_-Cf08JwlEeazaZ28rFZtgA" name="artifactURL">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_-Cf08JwlEeazaZ28rFZtgA" name="application">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_JHSiYP5uEeastMYiWd95zQ"/>
           </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_IHtKYJwmEeazaZ28rFZtgA" name="mainClass">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/EcorePrimitiveTypes.library.uml#EString"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_IHtKYJwmEeazaZ28rFZtgA" name="application_class">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_LAuwQP5uEeastMYiWd95zQ"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_QvTSUJwmEeazaZ28rFZtgA" name="base_Artifact" association="_QvNLsJwmEeazaZ28rFZtgA">
             <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Artifact"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8zyqEP5lEeastMYiWd95zQ" name="application_name">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_MWV4UP5uEeastMYiWd95zQ"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_9sbiQP5lEeastMYiWd95zQ" name="arguments">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_NWixEP5uEeastMYiWd95zQ"/>
           </ownedAttribute>
         </packagedElement>
         <packagedElement xmi:type="uml:Extension" xmi:id="_QvNLsJwmEeazaZ28rFZtgA" name="E_DdsmBigDataJob_Artifact1" memberEnd="_QvRdIJwmEeazaZ28rFZtgA _QvTSUJwmEeazaZ28rFZtgA">
@@ -870,6 +898,70 @@
         </packagedElement>
         <packagedElement xmi:type="uml:Extension" xmi:id="_pbqo8JwnEeazaZ28rFZtgA" name="E_DdsmJobDeployedFrom_Dependency1" memberEnd="_pbr3EJwnEeazaZ28rFZtgA _pbtFMJwnEeazaZ28rFZtgA">
           <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_pbr3EJwnEeazaZ28rFZtgA" name="extension_DdsmJobDeployedFrom" type="_d69l4JwnEeazaZ28rFZtgA" aggregation="composite" association="_pbqo8JwnEeazaZ28rFZtgA"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_Q1XXcP5lEeastMYiWd95zQ" name="DdsmMasterSlavePlatform">
+          <generalization xmi:type="uml:Generalization" xmi:id="_Ypxu8P5lEeastMYiWd95zQ" general="_VW6FIDx3EeaOH59TuV453g"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_FwSD8P5mEeastMYiWd95zQ" name="masterHost" type="_4GoMgDx3EeaOH59TuV453g">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_83AEMP5nEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_83B5YP5nEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_SIP7oP5lEeastMYiWd95zQ" name="DdsmPeerToPeerPlatform">
+          <generalization xmi:type="uml:Generalization" xmi:id="_ZGBmEP5lEeastMYiWd95zQ" general="_VW6FIDx3EeaOH59TuV453g"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_VVLKoP5lEeastMYiWd95zQ" name="DdsmHdfsCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_Wul0oP5lEeastMYiWd95zQ" general="_Q1XXcP5lEeastMYiWd95zQ"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Extension" xmi:id="_jH-MIP5lEeastMYiWd95zQ" name="E_DdsmStormCluster_ExecutionEnvironment1" memberEnd="_jIDEoP5lEeastMYiWd95zQ _jIESwP5lEeastMYiWd95zQ">
+          <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_jIDEoP5lEeastMYiWd95zQ" name="extension_DdsmStormCluster" type="_mNAuAD3UEeaPco63Cq703g" aggregation="composite" association="_jH-MIP5lEeastMYiWd95zQ"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Extension" xmi:id="_jhPAsP5lEeastMYiWd95zQ" name="E_DdsmYarnCluster_ExecutionEnvironment1" memberEnd="_jhPnwP5lEeastMYiWd95zQ _jhPnwf5lEeastMYiWd95zQ">
+          <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_jhPnwP5lEeastMYiWd95zQ" name="extension_DdsmYarnCluster" type="_bTMEwD3UEeaPco63Cq703g" aggregation="composite" association="_jhPAsP5lEeastMYiWd95zQ"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Extension" xmi:id="_kMouIP5lEeastMYiWd95zQ" name="E_DdsmKafkaCluster_ExecutionEnvironment1" memberEnd="_kMpVMP5lEeastMYiWd95zQ _kMp8QP5lEeastMYiWd95zQ">
+          <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_kMpVMP5lEeastMYiWd95zQ" name="extension_DdsmKafkaCluster" type="_jIPVcD3UEeaPco63Cq703g" aggregation="composite" association="_kMouIP5lEeastMYiWd95zQ"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Stereotype" xmi:id="_HWcwgP5mEeastMYiWd95zQ" name="DdsmCassandraCluster">
+          <generalization xmi:type="uml:Generalization" xmi:id="_I-3f0P5mEeastMYiWd95zQ" general="_SIP7oP5lEeastMYiWd95zQ"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_JbP50P5mEeastMYiWd95zQ" name="seedHost" type="_4GoMgDx3EeaOH59TuV453g">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BJU1AP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BJWqMP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_RmakcP5mEeastMYiWd95zQ" name="key_cache_keys_to_save">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JEmCcP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JEnQkP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_TaRHsP5mEeastMYiWd95zQ" name="key_cache_save_period">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IQoO4P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IQqEEP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_VFX-oP5mEeastMYiWd95zQ" name="memtable_cleanup_threshold">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HZlSIP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HZnHUP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_XYBWsP5mEeastMYiWd95zQ" name="memtable_flush_writers">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GLj_0P5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GLlN8P5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_aUxbsP5mEeastMYiWd95zQ" name="authenticator_enabled">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KkGtYP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KkH7gP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_bYdGQP5mEeastMYiWd95zQ" name="authorizer_enabled">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MPU5EP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MPWHMP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_dMGOIP5mEeastMYiWd95zQ" name="permission_validity_in_ms">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OE5TkP5oEeastMYiWd95zQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OE6hsP5oEeastMYiWd95zQ" value="1"/>
+          </ownedAttribute>
         </packagedElement>
         <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_iGZsADx2EeaOH59TuV453g">
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iG3mEDx2EeaOH59TuV453g" source="http://www.eclipse.org/uml2/2.0.0/UML">

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
@@ -661,6 +661,14 @@
           <element xsi:nil="true"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vw8p4ueaEeWj7ZPL8JeBTQ" x="210" y="478"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_Wop2oP5jEeastMYiWd95zQ" type="StereotypeComment">
+          <styles xmi:type="notation:TitleStyle" xmi:id="_Wop2of5jEeastMYiWd95zQ"/>
+          <styles xmi:type="notation:EObjectValueStyle" xmi:id="_WoqdsP5jEeastMYiWd95zQ" name="BASE_ELEMENT">
+            <eObjectValue xmi:type="uml:Profile" href="DICE_Library.uml#_diCmMOeWEeWj7ZPL8JeBTQ"/>
+          </styles>
+          <element xsi:nil="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wop2ov5jEeastMYiWd95zQ" x="209" y="12"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_bGrzgueVEeWj7ZPL8JeBTQ"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bGrzg-eVEeWj7ZPL8JeBTQ"/>
       </children>
@@ -711,21 +719,31 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mt9qgCyzEeagadxR5JgrcA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mt9qgSyzEeagadxR5JgrcA"/>
     </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Worr0P5jEeastMYiWd95zQ" type="StereotypeCommentLink" source="_diHesOeWEeWj7ZPL8JeBTQ" target="_Wop2oP5jEeastMYiWd95zQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Worr0f5jEeastMYiWd95zQ"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Wos58P5jEeastMYiWd95zQ" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Profile" href="DICE_Library.uml#_diCmMOeWEeWj7ZPL8JeBTQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Worr0v5jEeastMYiWd95zQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WosS4P5jEeastMYiWd95zQ"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WosS4f5jEeastMYiWd95zQ"/>
+    </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_6C-lMOeYEeWj7ZPL8JeBTQ" type="PapyrusUMLClassDiagram" name="Complex_DICE_Types" measurementUnit="Pixel">
-    <children xmi:type="notation:Shape" xmi:id="_8J-G4OeYEeWj7ZPL8JeBTQ" type="2007" fillColor="14012867">
-      <children xmi:type="notation:DecorationNode" xmi:id="_8J-G4ueYEeWj7ZPL8JeBTQ" type="5026"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_8J-G4-eYEeWj7ZPL8JeBTQ" type="7016">
-        <children xmi:type="notation:Shape" xmi:id="_GupmkOeZEeWj7ZPL8JeBTQ" type="3009" fillColor="14012867">
-          <children xmi:type="notation:DecorationNode" xmi:id="_GuqNoOeZEeWj7ZPL8JeBTQ" type="5017"/>
-          <children xmi:type="notation:BasicCompartment" xmi:id="_GuqNoeeZEeWj7ZPL8JeBTQ" type="7010">
-            <children xmi:type="notation:Shape" xmi:id="_avyc0OedEeWj7ZPL8JeBTQ" type="3027">
-              <children xmi:type="notation:DecorationNode" xmi:id="_avzD4OedEeWj7ZPL8JeBTQ" type="5061"/>
-              <children xmi:type="notation:DecorationNode" xmi:id="_avzD4eedEeWj7ZPL8JeBTQ" type="8520">
+    <children xmi:type="notation:Shape" xmi:id="_8J-G4OeYEeWj7ZPL8JeBTQ" type="Package_Shape" fillColor="14012867">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8J-G4ueYEeWj7ZPL8JeBTQ" type="Package_NameLabel"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8J-G4-eYEeWj7ZPL8JeBTQ" type="Package_PackagedElementCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_GupmkOeZEeWj7ZPL8JeBTQ" type="Package_Shape_CN" fillColor="14012867">
+          <children xmi:type="notation:DecorationNode" xmi:id="_GuqNoOeZEeWj7ZPL8JeBTQ" type="Package_NameLabel_CN"/>
+          <children xmi:type="notation:BasicCompartment" xmi:id="_GuqNoeeZEeWj7ZPL8JeBTQ" type="Package_PackagedElementCompartment_CN">
+            <children xmi:type="notation:Shape" xmi:id="_avyc0OedEeWj7ZPL8JeBTQ" type="DataType_Shape_CN">
+              <children xmi:type="notation:DecorationNode" xmi:id="_avzD4OedEeWj7ZPL8JeBTQ" type="DataType_NameLabel_CN"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_avzD4eedEeWj7ZPL8JeBTQ" type="DataType_FloatingNameLabel_CN">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_avzD4uedEeWj7ZPL8JeBTQ" y="5"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_avzD4-edEeWj7ZPL8JeBTQ" type="7032">
-                <children xmi:type="notation:Shape" xmi:id="_nBEBMOedEeWj7ZPL8JeBTQ" type="3018">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_avzD4-edEeWj7ZPL8JeBTQ" type="DataType_AttributeCompartment_CN">
+                <children xmi:type="notation:Shape" xmi:id="_nBEBMOedEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_nA96kOedEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_nBEBMeedEeWj7ZPL8JeBTQ"/>
                 </children>
@@ -734,7 +752,7 @@
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_avzD5uedEeWj7ZPL8JeBTQ"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_avzD5-edEeWj7ZPL8JeBTQ"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_avzD6OedEeWj7ZPL8JeBTQ" type="7033">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_avzD6OedEeWj7ZPL8JeBTQ" type="DataType_OperationCompartment_CN">
                 <styles xmi:type="notation:TitleStyle" xmi:id="_avzD6eedEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_avzD6uedEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_avzD6-edEeWj7ZPL8JeBTQ"/>
@@ -743,25 +761,25 @@
               <element xmi:type="uml:DataType" href="DICE_Library.uml#_avs9QOedEeWj7ZPL8JeBTQ"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_avyc0eedEeWj7ZPL8JeBTQ" x="19" y="14" width="266"/>
             </children>
-            <children xmi:type="notation:Shape" xmi:id="_deoosOedEeWj7ZPL8JeBTQ" type="3027">
-              <children xmi:type="notation:DecorationNode" xmi:id="_deoosuedEeWj7ZPL8JeBTQ" type="5061"/>
-              <children xmi:type="notation:DecorationNode" xmi:id="_deoos-edEeWj7ZPL8JeBTQ" type="8520">
+            <children xmi:type="notation:Shape" xmi:id="_deoosOedEeWj7ZPL8JeBTQ" type="DataType_Shape_CN">
+              <children xmi:type="notation:DecorationNode" xmi:id="_deoosuedEeWj7ZPL8JeBTQ" type="DataType_NameLabel_CN"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_deoos-edEeWj7ZPL8JeBTQ" type="DataType_FloatingNameLabel_CN">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_deootOedEeWj7ZPL8JeBTQ" y="5"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_deooteedEeWj7ZPL8JeBTQ" type="7032">
-                <children xmi:type="notation:Shape" xmi:id="_QX4i8OefEeWj7ZPL8JeBTQ" type="3018">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_deooteedEeWj7ZPL8JeBTQ" type="DataType_AttributeCompartment_CN">
+                <children xmi:type="notation:Shape" xmi:id="_QX4i8OefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_QXwnIOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_QX4i8eefEeWj7ZPL8JeBTQ"/>
                 </children>
-                <children xmi:type="notation:Shape" xmi:id="_dsU0gOefEeWj7ZPL8JeBTQ" type="3018">
+                <children xmi:type="notation:Shape" xmi:id="_dsU0gOefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_dsLqkOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_dsU0geefEeWj7ZPL8JeBTQ"/>
                 </children>
-                <children xmi:type="notation:Shape" xmi:id="_e8Vq4OefEeWj7ZPL8JeBTQ" type="3018">
+                <children xmi:type="notation:Shape" xmi:id="_e8Vq4OefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_e8OWIOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_e8Vq4eefEeWj7ZPL8JeBTQ"/>
                 </children>
-                <children xmi:type="notation:Shape" xmi:id="_gQZTwOefEeWj7ZPL8JeBTQ" type="3018">
+                <children xmi:type="notation:Shape" xmi:id="_gQZTwOefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_gQTNIOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_gQZTweefEeWj7ZPL8JeBTQ"/>
                 </children>
@@ -770,7 +788,7 @@
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_deoouOedEeWj7ZPL8JeBTQ"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_deooueedEeWj7ZPL8JeBTQ"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_deoouuedEeWj7ZPL8JeBTQ" type="7033">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_deoouuedEeWj7ZPL8JeBTQ" type="DataType_OperationCompartment_CN">
                 <styles xmi:type="notation:TitleStyle" xmi:id="_deoou-edEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_deoovOedEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_deooveedEeWj7ZPL8JeBTQ"/>
@@ -779,17 +797,17 @@
               <element xmi:type="uml:DataType" href="DICE_Library.uml#_dejJIOedEeWj7ZPL8JeBTQ"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_deooseedEeWj7ZPL8JeBTQ" x="18" y="126" width="266"/>
             </children>
-            <children xmi:type="notation:Shape" xmi:id="_FX8qoOefEeWj7ZPL8JeBTQ" type="3027">
-              <children xmi:type="notation:DecorationNode" xmi:id="_FX8qouefEeWj7ZPL8JeBTQ" type="5061"/>
-              <children xmi:type="notation:DecorationNode" xmi:id="_FX8qo-efEeWj7ZPL8JeBTQ" type="8520">
+            <children xmi:type="notation:Shape" xmi:id="_FX8qoOefEeWj7ZPL8JeBTQ" type="DataType_Shape_CN">
+              <children xmi:type="notation:DecorationNode" xmi:id="_FX8qouefEeWj7ZPL8JeBTQ" type="DataType_NameLabel_CN"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_FX8qo-efEeWj7ZPL8JeBTQ" type="DataType_FloatingNameLabel_CN">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_FX8qpOefEeWj7ZPL8JeBTQ" y="5"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_FX8qpeefEeWj7ZPL8JeBTQ" type="7032">
-                <children xmi:type="notation:Shape" xmi:id="_HmzH0OefEeWj7ZPL8JeBTQ" type="3018">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_FX8qpeefEeWj7ZPL8JeBTQ" type="DataType_AttributeCompartment_CN">
+                <children xmi:type="notation:Shape" xmi:id="_HmzH0OefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_HmrzEOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_HmzH0eefEeWj7ZPL8JeBTQ"/>
                 </children>
-                <children xmi:type="notation:Shape" xmi:id="_NAWmcOefEeWj7ZPL8JeBTQ" type="3018">
+                <children xmi:type="notation:Shape" xmi:id="_NAWmcOefEeWj7ZPL8JeBTQ" type="Property_DataTypeAttributeLabel">
                   <element xmi:type="uml:Property" href="DICE_Library.uml#_NAODkOefEeWj7ZPL8JeBTQ"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_NAWmceefEeWj7ZPL8JeBTQ"/>
                 </children>
@@ -798,7 +816,7 @@
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_FX8qqOefEeWj7ZPL8JeBTQ"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FX8qqeefEeWj7ZPL8JeBTQ"/>
               </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_FX8qquefEeWj7ZPL8JeBTQ" type="7033">
+              <children xmi:type="notation:BasicCompartment" xmi:id="_FX8qquefEeWj7ZPL8JeBTQ" type="DataType_OperationCompartment_CN">
                 <styles xmi:type="notation:TitleStyle" xmi:id="_FX8qq-efEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_FX8qrOefEeWj7ZPL8JeBTQ"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_FX8qreefEeWj7ZPL8JeBTQ"/>
@@ -835,7 +853,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xvfaNeeaEeWj7ZPL8JeBTQ" x="232" y="24"/>
     </children>
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_6C-lMeeYEeWj7ZPL8JeBTQ" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_6C-lMeeYEeWj7ZPL8JeBTQ" name="diagram_compatibility_version" stringValue="1.2.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_6C-lMueYEeWj7ZPL8JeBTQ"/>
     <styles xmi:type="style:PapyrusViewStyle" xmi:id="_6C-lM-eYEeWj7ZPL8JeBTQ">
       <owner xmi:type="uml:Model" href="DICE_Library.uml#_mTBX0OePEeWj7ZPL8JeBTQ"/>

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
@@ -85,12 +85,12 @@
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_SaOdcDiZEeaFI4EbHcf0UA" name="fair"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_HOIsID4CEeahGZm0A1o1gg" name="VMSize">
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MfkJgD4CEeahGZm0A1o1gg" name="small"/>
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Q4qQsD4CEeahGZm0A1o1gg" name="medium"/>
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_TM8ngD4CEeahGZm0A1o1gg" name="large"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MfkJgD4CEeahGZm0A1o1gg" name="Small"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Q4qQsD4CEeahGZm0A1o1gg" name="Medium"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_TM8ngD4CEeahGZm0A1o1gg" name="Large"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_ToY-oD4IEeahGZm0A1o1gg" name="ProviderType">
-          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VrthQD4IEeahGZm0A1o1gg" name="flexiant"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VrthQD4IEeahGZm0A1o1gg" name="fco"/>
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Xqh-YD4IEeahGZm0A1o1gg" name="openstack"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_JBGoID4OEeahGZm0A1o1gg" name="LifeCycleElementType">


### PR DESCRIPTION
This PR fixes and adds various thing in the DICE DDSM profile. The updates have been done mainly to support the generation of TOSCA blueprints from stereotyped Deployment Diagrams. @perezp can you have a look?