### PR TITLE
Adding monitoring and custom deployment support to DDSM profile package.

### DIFF
--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.notation
@@ -1707,13 +1707,13 @@
           <element xmi:type="uml:Property" href="DICE.profile.uml#_n26yEP5mEeastMYiWd95zQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_n3WP4f5mEeastMYiWd95zQ"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_8BMZcAKMEeeo9amVjAoIhA" type="Property_ClassAttributeLabel">
-          <element xmi:type="uml:Property" href="DICE.profile.uml#_8AsDIAKMEeeo9amVjAoIhA"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_8BMZcQKMEeeo9amVjAoIhA"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_T_AS0ANQEeeNS8hZS_VTiQ" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="DICE.profile.uml#_T9-_IANQEeeNS8hZS_VTiQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_T_AS0QNQEeeNS8hZS_VTiQ"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_a25c8BOREeeqarsdcU2oLw" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_a17MkBOREeeqarsdcU2oLw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_a25c8ROREeeqarsdcU2oLw"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_VW7TRDx3EeaOH59TuV453g"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_VW7TRTx3EeaOH59TuV453g"/>
@@ -2021,6 +2021,14 @@
         <children xmi:type="notation:Shape" xmi:id="_fRFtoD3oEeaPco63Cq703g" type="Property_ClassAttributeLabel">
           <element xmi:type="uml:Property" href="DICE.profile.uml#_fQ_nAD3oEeaPco63Cq703g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_fRFtoT3oEeaPco63Cq703g"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_7xKyEBGCEeek-vqfmGWZmg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_7psREBGCEeek-vqfmGWZmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_7xKyERGCEeek-vqfmGWZmg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_gQz-8BGDEeek-vqfmGWZmg" type="Property_ClassAttributeLabel">
+          <element xmi:type="uml:Property" href="DICE.profile.uml#_gPr9kBGDEeek-vqfmGWZmg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_gQz-8RGDEeek-vqfmGWZmg"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_Q0DcUj3oEeaPco63Cq703g"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_Q0DcUz3oEeaPco63Cq703g"/>

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE.profile.uml
@@ -642,6 +642,7 @@
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fbY-gD37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fbZlkD37EeahGZm0A1o1gg" value="1"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_OUbToBIMEeeObJA3SYVWAw" value="ubuntu"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_gJR_QD37EeahGZm0A1o1gg" name="password">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
@@ -692,16 +693,15 @@
               <instance xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_WrORcAAvEee5FrQsk8AM1w"/>
             </defaultValue>
           </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_8AsDIAKMEeeo9amVjAoIhA" name="enable_monitoring">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9fgKgAKMEeeo9amVjAoIhA"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9fkb8AKMEeeo9amVjAoIhA" value="1"/>
-            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_-_c6UAKMEeeo9amVjAoIhA"/>
-          </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_T9-_IANQEeeNS8hZS_VTiQ" name="firewallRules">
-            <type xmi:type="uml:DataType" href="DICE_Library.uml#_YKdksAAxEee5FrQsk8AM1w"/>
+            <type xmi:type="uml:DataType" href="DICE_Library.uml#_37SOMBQKEeerG-qiQF7PAA"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VidCkANQEeeNS8hZS_VTiQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VigF4ANQEeeNS8hZS_VTiQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_a17MkBOREeeqarsdcU2oLw" name="requiredAttributes">
+            <type xmi:type="uml:DataType" href="DICE_Library.uml#_mT3EgBQKEeerG-qiQF7PAA"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hqfQoBOREeeqarsdcU2oLw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hql-UBOREeeqarsdcU2oLw" value="*"/>
           </ownedAttribute>
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_2gRSsDx3EeaOH59TuV453g" name="DdsmHeterogeneousCluster">
@@ -772,6 +772,7 @@
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8_RTID37EeahGZm0A1o1gg"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8_R6MD37EeahGZm0A1o1gg" value="1"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_a4qQQBIMEeeObJA3SYVWAw" value="/root/.ssh/agent.key"/>
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="__CBOAD37EeahGZm0A1o1gg" name="publicAddress">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
@@ -1003,6 +1004,17 @@
           <ownedAttribute xmi:type="uml:Property" xmi:id="_fQ_nAD3oEeaPco63Cq703g" name="providedPortsList" type="_cyK-sD3pEeaPco63Cq703g">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hmSDYD3oEeaPco63Cq703g"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hmSqcD3oEeaPco63Cq703g" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_7psREBGCEeek-vqfmGWZmg" name="monitored">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__vm9kBGCEeek-vqfmGWZmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__vx8sBGCEeek-vqfmGWZmg" value="1"/>
+            <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_E9hz8BGDEeek-vqfmGWZmg"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_gPr9kBGDEeek-vqfmGWZmg" name="monitoringRoles">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_h_gVYBGDEeek-vqfmGWZmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_h_ixoBGDEeek-vqfmGWZmg" value="*"/>
           </ownedAttribute>
         </packagedElement>
         <packagedElement xmi:type="uml:Stereotype" xmi:id="_cyK-sD3pEeaPco63Cq703g" name="DdsmPort">

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
@@ -761,35 +761,7 @@
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Egcmzj4WEeahGZm0A1o1gg"/>
               </children>
               <element xmi:type="uml:DataType" href="DICE_Library.uml#_EgSOsD4WEeahGZm0A1o1gg"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgcmwT4WEeahGZm0A1o1gg" x="274" y="21"/>
-            </children>
-            <children xmi:type="notation:Shape" xmi:id="_YLF20AAxEee5FrQsk8AM1w" type="DataType_Shape_CN">
-              <children xmi:type="notation:DecorationNode" xmi:id="_YLGd4AAxEee5FrQsk8AM1w" type="DataType_NameLabel_CN"/>
-              <children xmi:type="notation:DecorationNode" xmi:id="_YLGd4QAxEee5FrQsk8AM1w" type="DataType_FloatingNameLabel_CN">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_YLGd4gAxEee5FrQsk8AM1w" y="5"/>
-              </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_YLGd4wAxEee5FrQsk8AM1w" type="DataType_AttributeCompartment_CN">
-                <children xmi:type="notation:Shape" xmi:id="_hiMJEAAxEee5FrQsk8AM1w" type="Property_DataTypeAttributeLabel">
-                  <element xmi:type="uml:Property" href="DICE_Library.uml#_hgHsgAAxEee5FrQsk8AM1w"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_hiMJEQAxEee5FrQsk8AM1w"/>
-                </children>
-                <children xmi:type="notation:Shape" xmi:id="_yKCsIAAxEee5FrQsk8AM1w" type="Property_DataTypeAttributeLabel">
-                  <element xmi:type="uml:Property" href="DICE_Library.uml#_yJi84AAxEee5FrQsk8AM1w"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_yKCsIQAxEee5FrQsk8AM1w"/>
-                </children>
-                <styles xmi:type="notation:TitleStyle" xmi:id="_YLGd5AAxEee5FrQsk8AM1w"/>
-                <styles xmi:type="notation:SortingStyle" xmi:id="_YLGd5QAxEee5FrQsk8AM1w"/>
-                <styles xmi:type="notation:FilteringStyle" xmi:id="_YLGd5gAxEee5FrQsk8AM1w"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YLGd5wAxEee5FrQsk8AM1w"/>
-              </children>
-              <children xmi:type="notation:BasicCompartment" xmi:id="_YLGd6AAxEee5FrQsk8AM1w" type="DataType_OperationCompartment_CN">
-                <styles xmi:type="notation:TitleStyle" xmi:id="_YLGd6QAxEee5FrQsk8AM1w"/>
-                <styles xmi:type="notation:SortingStyle" xmi:id="_YLGd6gAxEee5FrQsk8AM1w"/>
-                <styles xmi:type="notation:FilteringStyle" xmi:id="_YLGd6wAxEee5FrQsk8AM1w"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YLGd7AAxEee5FrQsk8AM1w"/>
-              </children>
-              <element xmi:type="uml:DataType" href="DICE_Library.uml#_YKdksAAxEee5FrQsk8AM1w"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YLF20QAxEee5FrQsk8AM1w" x="587" y="32"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EgcmwT4WEeahGZm0A1o1gg" x="185" y="21"/>
             </children>
             <styles xmi:type="notation:TitleStyle" xmi:id="_yQqfc-eYEeWj7ZPL8JeBTQ"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yQqfdOeYEeWj7ZPL8JeBTQ"/>
@@ -968,6 +940,62 @@
               </children>
               <element xmi:type="uml:DataType" href="DICE_Library.uml#_FX3yIOefEeWj7ZPL8JeBTQ"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FX8qoeefEeWj7ZPL8JeBTQ" x="313" y="13" width="266"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_mUNCwBQKEeerG-qiQF7PAA" type="DataType_Shape_CN">
+              <children xmi:type="notation:DecorationNode" xmi:id="_mUPfABQKEeerG-qiQF7PAA" type="DataType_NameLabel_CN"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_mUPfARQKEeerG-qiQF7PAA" type="DataType_FloatingNameLabel_CN">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_mUPfAhQKEeerG-qiQF7PAA" y="5"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_mUQtIBQKEeerG-qiQF7PAA" type="DataType_AttributeCompartment_CN">
+                <children xmi:type="notation:Shape" xmi:id="_qiCVIBQKEeerG-qiQF7PAA" type="Property_DataTypeAttributeLabel">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_qhwoUBQKEeerG-qiQF7PAA"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_qiCVIRQKEeerG-qiQF7PAA"/>
+                </children>
+                <children xmi:type="notation:Shape" xmi:id="_rpKVQBQKEeerG-qiQF7PAA" type="Property_DataTypeAttributeLabel">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_ro52kBQKEeerG-qiQF7PAA"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_rpKVQRQKEeerG-qiQF7PAA"/>
+                </children>
+                <styles xmi:type="notation:TitleStyle" xmi:id="_mUQtIRQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_mUQtIhQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_mUQtIxQKEeerG-qiQF7PAA"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mUQtJBQKEeerG-qiQF7PAA"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_mUQtJRQKEeerG-qiQF7PAA" type="DataType_OperationCompartment_CN">
+                <styles xmi:type="notation:TitleStyle" xmi:id="_mUQtJhQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_mUQtJxQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_mUQtKBQKEeerG-qiQF7PAA"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mUQtKRQKEeerG-qiQF7PAA"/>
+              </children>
+              <element xmi:type="uml:DataType" href="DICE_Library.uml#_mT3EgBQKEeerG-qiQF7PAA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mUNCwRQKEeerG-qiQF7PAA" x="313" y="129" width="273" height="128"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_37jT8BQKEeerG-qiQF7PAA" type="DataType_Shape_CN">
+              <children xmi:type="notation:DecorationNode" xmi:id="_37j7ABQKEeerG-qiQF7PAA" type="DataType_NameLabel_CN"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_37j7ARQKEeerG-qiQF7PAA" type="DataType_FloatingNameLabel_CN">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_37kiEBQKEeerG-qiQF7PAA" y="5"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_37kiERQKEeerG-qiQF7PAA" type="DataType_AttributeCompartment_CN">
+                <children xmi:type="notation:Shape" xmi:id="_9HLEQBQKEeerG-qiQF7PAA" type="Property_DataTypeAttributeLabel">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_9G-3ABQKEeerG-qiQF7PAA"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_9HLEQRQKEeerG-qiQF7PAA"/>
+                </children>
+                <children xmi:type="notation:Shape" xmi:id="_-kL00BQKEeerG-qiQF7PAA" type="Property_DataTypeAttributeLabel">
+                  <element xmi:type="uml:Property" href="DICE_Library.uml#_-j9yYBQKEeerG-qiQF7PAA"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-kL00RQKEeerG-qiQF7PAA"/>
+                </children>
+                <styles xmi:type="notation:TitleStyle" xmi:id="_37kiEhQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_37kiExQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_37kiFBQKEeerG-qiQF7PAA"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_37kiFRQKEeerG-qiQF7PAA"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_37kiFhQKEeerG-qiQF7PAA" type="DataType_OperationCompartment_CN">
+                <styles xmi:type="notation:TitleStyle" xmi:id="_37kiFxQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_37kiGBQKEeerG-qiQF7PAA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_37kiGRQKEeerG-qiQF7PAA"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_37kiGhQKEeerG-qiQF7PAA"/>
+              </children>
+              <element xmi:type="uml:DataType" href="DICE_Library.uml#_37SOMBQKEeerG-qiQF7PAA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_37jT8RQKEeerG-qiQF7PAA" x="23" y="280" width="261" height="122"/>
             </children>
             <styles xmi:type="notation:TitleStyle" xmi:id="_GuqNoueZEeWj7ZPL8JeBTQ"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GuqNo-eZEeWj7ZPL8JeBTQ"/>

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
@@ -156,19 +156,6 @@
           </ownedAttribute>
           <ownedAttribute xmi:type="uml:Property" xmi:id="_SF_PYD4WEeahGZm0A1o1gg" name="scriptKind" type="_JBGoID4OEeahGZm0A1o1gg"/>
         </packagedElement>
-        <packagedElement xmi:type="uml:DataType" xmi:id="_YKdksAAxEee5FrQsk8AM1w" name="FirewallRule">
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_hgHsgAAxEee5FrQsk8AM1w" name="allowedIpPrefix">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qzJXEAAxEee5FrQsk8AM1w"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qzPdsAAxEee5FrQsk8AM1w" value="1"/>
-            <defaultValue xmi:type="uml:LiteralString" xmi:id="_NuYgsAP9EeeNS8hZS_VTiQ" value="0.0.0.0/0"/>
-          </ownedAttribute>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_yJi84AAxEee5FrQsk8AM1w" name="port">
-            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4EWgoANhEeeNS8hZS_VTiQ"/>
-            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4EZj8ANhEeeNS8hZS_VTiQ" value="1"/>
-          </ownedAttribute>
-        </packagedElement>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_8J84wOeYEeWj7ZPL8JeBTQ" name="Complex_DICE_Types">
@@ -210,6 +197,27 @@
             <type xmi:type="uml:DataType" href="pathmap://Papyrus_LIBRARIES/MARTE_Library.library.uml#_5LrMcBFSEdyUJeMeN__D-A"/>
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_amrSMOefEeWj7ZPL8JeBTQ"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_amsgUOefEeWj7ZPL8JeBTQ" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_mT3EgBQKEeerG-qiQF7PAA" name="RequiredAttribute">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_qhwoUBQKEeerG-qiQF7PAA" name="referenceNode">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_ro52kBQKEeerG-qiQF7PAA" name="attributeName">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_37SOMBQKEeerG-qiQF7PAA" name="FirewallRule">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_9G-3ABQKEeerG-qiQF7PAA" name="allowedIpPrefix">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_L2exUBQLEeerG-qiQF7PAA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_L2h0oBQLEeerG-qiQF7PAA" value="1"/>
+            <defaultValue xmi:type="uml:LiteralString" xmi:id="_JCcjcBQLEeerG-qiQF7PAA" value="0.0.0.0/0"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_-j9yYBQKEeerG-qiQF7PAA" name="port">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KzPLoBQLEeerG-qiQF7PAA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KzS2ABQLEeerG-qiQF7PAA" value="1"/>
           </ownedAttribute>
         </packagedElement>
       </packagedElement>


### PR DESCRIPTION
This PR adds few properties to the DDSM package and data types to the DICE library in order to be able to:

- enable the monitoring of deployed services and components.
- fully specify a custom deployment model, using custom VM images and custom nodes, mainly to enable the Posidonia case study.

@perezp can you have a look?