### PR TITLE
Feature/update secureuml and aws provider

### DIFF
--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.notation
@@ -434,6 +434,10 @@
                   <element xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_Xqh-YD4IEeahGZm0A1o1gg"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_XquLoT4IEeahGZm0A1o1gg"/>
                 </children>
+                <children xmi:type="notation:Shape" xmi:id="_vYGw0FflEeefbOVX5L95Fg" type="EnumerationLiteral_LiteralLabel">
+                  <element xmi:type="uml:EnumerationLiteral" href="DICE_Library.uml#_vWzJQFflEeefbOVX5L95Fg"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_vYGw0VflEeefbOVX5L95Fg"/>
+                </children>
                 <styles xmi:type="notation:TitleStyle" xmi:id="_TolL5j4IEeahGZm0A1o1gg"/>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_TolL5z4IEeahGZm0A1o1gg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_TolL6D4IEeahGZm0A1o1gg"/>

--- a/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
+++ b/bundles/es.unizar.disco.dice.static.profile/resources/DICE_Library.uml
@@ -92,6 +92,7 @@
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_ToY-oD4IEeahGZm0A1o1gg" name="ProviderType">
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VrthQD4IEeahGZm0A1o1gg" name="fco"/>
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Xqh-YD4IEeahGZm0A1o1gg" name="openstack"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vWzJQFflEeefbOVX5L95Fg" name="aws"/>
         </packagedElement>
         <packagedElement xmi:type="uml:Enumeration" xmi:id="_JBGoID4OEeahGZm0A1o1gg" name="LifeCycleElementType">
           <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_L6TC0D4OEeahGZm0A1o1gg" name="start"/>

--- a/bundles/ro.ieat.secureuml.profile/resources/SecureUML.profile.notation
+++ b/bundles/ro.ieat.secureuml.profile/resources/SecureUML.profile.notation
@@ -259,6 +259,27 @@
         <element xsi:nil="true"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6LWeQj0wEeaLdOHMYkCk2Q" x="731" y="18"/>
       </children>
+      <children xmi:type="notation:Shape" xmi:id="_T44JAFDpEeez1vSxqhhUSw" type="Stereotype_Shape_CN">
+        <children xmi:type="notation:DecorationNode" xmi:id="_T46lQFDpEeez1vSxqhhUSw" type="Stereotype_NameLabel_CN"/>
+        <children xmi:type="notation:BasicCompartment" xmi:id="_T46lQVDpEeez1vSxqhhUSw" type="Stereotype_AttributeCompartment_CN">
+          <children xmi:type="notation:Shape" xmi:id="_WtV0sFDpEeez1vSxqhhUSw" type="Property_ClassAttributeLabel">
+            <element xmi:type="uml:Property" href="SecureUML.profile.uml#_WseSAFDpEeez1vSxqhhUSw"/>
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_WtV0sVDpEeez1vSxqhhUSw"/>
+          </children>
+          <styles xmi:type="notation:TitleStyle" xmi:id="_T46lQlDpEeez1vSxqhhUSw"/>
+          <styles xmi:type="notation:SortingStyle" xmi:id="_T46lQ1DpEeez1vSxqhhUSw"/>
+          <styles xmi:type="notation:FilteringStyle" xmi:id="_T46lRFDpEeez1vSxqhhUSw"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T46lRVDpEeez1vSxqhhUSw"/>
+        </children>
+        <children xmi:type="notation:BasicCompartment" xmi:id="_T46lRlDpEeez1vSxqhhUSw" type="Stereotype_OperationCompartment_CN">
+          <styles xmi:type="notation:TitleStyle" xmi:id="_T46lR1DpEeez1vSxqhhUSw"/>
+          <styles xmi:type="notation:SortingStyle" xmi:id="_T46lSFDpEeez1vSxqhhUSw"/>
+          <styles xmi:type="notation:FilteringStyle" xmi:id="_T46lSVDpEeez1vSxqhhUSw"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T46lSlDpEeez1vSxqhhUSw"/>
+        </children>
+        <element xmi:type="uml:Stereotype" href="SecureUML.profile.uml#_T4B0cFDpEeez1vSxqhhUSw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_T44JAVDpEeez1vSxqhhUSw" x="530" y="397"/>
+      </children>
       <styles xmi:type="notation:TitleStyle" xmi:id="_K-xjMTIwEeaCqKWE88ztuQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_K-xjMjIwEeaCqKWE88ztuQ"/>
     </children>
@@ -810,5 +831,12 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WHzfInmXEeae1LmHHETvPg" points="[975, 271, -643984, -643984]$[1104, 128, -643984, -643984]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WIYG4HmXEeae1LmHHETvPg" id="(0.89,0.0)"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WIYG4XmXEeae1LmHHETvPg" id="(0.23,1.0)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_VQBiIFDpEeez1vSxqhhUSw" type="Extension_Edge" source="_T44JAFDpEeez1vSxqhhUSw" target="_ctYt4DkeEeaBBfuA_Eus3A">
+    <styles xmi:type="notation:FontStyle" xmi:id="_VQBiIVDpEeez1vSxqhhUSw"/>
+    <element xmi:type="uml:Extension" href="SecureUML.profile.uml#_VPMbsFDpEeez1vSxqhhUSw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQBiIlDpEeez1vSxqhhUSw" points="[580, 377, -643984, -643984]$[394, 234, -643984, -643984]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VRorsFDpEeez1vSxqhhUSw" id="(0.26,0.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VRp50FDpEeez1vSxqhhUSw" id="(0.82,1.0)"/>
   </edges>
 </notation:Diagram>

--- a/bundles/ro.ieat.secureuml.profile/resources/SecureUML.profile.uml
+++ b/bundles/ro.ieat.secureuml.profile/resources/SecureUML.profile.uml
@@ -8526,6 +8526,17 @@
     <packagedElement xmi:type="uml:Extension" xmi:id="_WHIwwHmXEeae1LmHHETvPg" name="E_Action_Classifier1" memberEnd="_WHIwwXmXEeae1LmHHETvPg _WHO3YHmXEeae1LmHHETvPg">
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_WHIwwXmXEeae1LmHHETvPg" name="extension_Action" type="_G6VVADI-EeaCqKWE88ztuQ" aggregation="composite" association="_WHIwwHmXEeae1LmHHETvPg"/>
     </packagedElement>
+    <packagedElement xmi:type="uml:Stereotype" xmi:id="_T4B0cFDpEeez1vSxqhhUSw" name="ResourceType">
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_VPQGEFDpEeez1vSxqhhUSw" name="base_Classifier" association="_VPMbsFDpEeez1vSxqhhUSw">
+        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Classifier"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_WseSAFDpEeez1vSxqhhUSw" name="baseClass">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Extension" xmi:id="_VPMbsFDpEeez1vSxqhhUSw" name="E_ResourceType_Classifier1" memberEnd="_VPPfAFDpEeez1vSxqhhUSw _VPQGEFDpEeez1vSxqhhUSw">
+      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_VPPfAFDpEeez1vSxqhhUSw" name="extension_ResourceType" type="_T4B0cFDpEeez1vSxqhhUSw" aggregation="composite" association="_VPMbsFDpEeez1vSxqhhUSw"/>
+    </packagedElement>
   </packagedElement>
   <packagedElement xmi:type="uml:Association" xmi:id="_LaDTgDI8EeaCqKWE88ztuQ" name="UserAssociation" isAbstract="true" memberEnd="_LaDTgzI8EeaCqKWE88ztuQ _LaD6kDI8EeaCqKWE88ztuQ">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LaDTgTI8EeaCqKWE88ztuQ" source="org.eclipse.papyrus">


### PR DESCRIPTION
This PR slightly update the SecureUML profile adding the ResourceType stereotype to model the set of resources that can be constrained by a given Permission. This stereotype is missing in the current implementation of the profile, but is discussed in the original paper on SecureUML. This update should allow to create complete SecureUML models.

The PR also adds AWS among the providers available in the DDSM profile.

@perezp can you have a look?